### PR TITLE
Avoid an exception when response isn't JSON-formatted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.egg-info
+/.pytest_cache/

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,8 @@ console_scripts =
 dev =
 
 test =
+    pytest
+    pytest-mock
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018 PeopleDoc, created by Pierre-Louis Bonicoli
+
+import io
+import pytest
+from urllib3.response import HTTPResponse
+
+import requests
+from vault_cli.vault_python_api import create_session, userpass_authentication
+
+
+@pytest.fixture
+def mock_request(request, mocker):
+    response = request.getfuncargvalue('testcase')
+
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None,
+             proxies=None):
+        data = response['data']
+        resp = HTTPResponse(body=io.BytesIO(data), preload_content=False)
+        resp.status = response['status']
+        resp.reason = response['reason']
+        resp.headers = {}
+        return self.build_response(request, resp)
+
+    mocker.patch('requests.adapters.HTTPAdapter.send', autospec=True,
+                 side_effect=send)
+
+
+TEST_CASE = [
+    {
+        'data': b'404 page not found',
+        'reason': 'Not Found',
+        'status': 404,
+    }
+]
+
+
+@pytest.mark.parametrize('testcase', TEST_CASE)
+def test_wrong_url(mocker, mock_request, testcase):
+    """Check that an exception doesn't occur when URL provided by user is
+    wrong"""
+
+    session = create_session(True)
+    with pytest.raises(ValueError) as excinfo:
+        userpass_authentication(session, 'https://localhost:8200/', 'user', 'pass')
+    assert requests.adapters.HTTPAdapter.send.call_count == 1
+    assert "Wrong username or password (HTTP code: 404)" == str(excinfo.value)

--- a/vault_cli/vault_python_api.py
+++ b/vault_cli/vault_python_api.py
@@ -45,13 +45,14 @@ def userpass_authentication(session, url, username, password):
     data = {"password": password}
     response = session.post(url + 'auth/userpass/login/' + username,
                             json=data, headers={})
-    json_response = response.json()
 
     if response.status_code == requests.codes.ok:
+        json_response = response.json()
         session.headers.update(
             {'X-Vault-Token': json_response.get('auth').get('client_token')})
     else:
-        raise ValueError('Wrong username or password')
+        raise ValueError('Wrong username or password (HTTP code: %s)' %
+                         response.status_code)
 
 
 # TODO


### PR DESCRIPTION
This could occur when user provided an incorrect URL.