### PR TITLE
Vault cli improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,18 @@ blob_secret:
 test:
   my_folder_secret: azerty
 
+# Get a nested secret based on a path
+$ vault get test/my_folder_secret
+test:
+  my_folder_secret: azerty
+
+# Get a nested secret without root key without a key
+$ vault get --without-key test/my_folder_secret
+--- azerty
+...
+
 # Get all values from a folder in a single command (yaml format)
-$ vault get-all folder
+$ vault get-all test
 ---
 my_folder_secret: azerty
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,17 @@ qwerty
 $ vault set my_other_secret supersecret
 Done
 
+# Add a secret object
+$ vault set --yaml blob_secret "{code: supercode}"
+Done
+
 # Get all values from the vault in a single command (yaml format)
 $ vault get-all
 ---
 my_secret: qwerty
 my_other_secret: supersecret
+blob_secret:
+  code: supercode
 test:
   my_folder_secret: azerty
 

--- a/vault_cli/vault.py
+++ b/vault_cli/vault.py
@@ -90,11 +90,34 @@ def get_all(session, path):
                              explicit_start=True))
 
 
+def nested_keys(path, value):
+    """
+    >>> nested_path('test', 'foo')
+    {'test': 'foo'}
+
+    >>> nested_path('test/bla', 'foo')
+    {'test': {'bla': 'foo'}}
+    """
+    try:
+        base, subpath = path.strip('/').split('/', 1)
+    except ValueError:
+        return {path: value}
+    return {base: nested_keys(subpath, value)}
+
+
 @click.command()
 @click.pass_obj
 @click.option('--text', is_flag=True)
+@click.option('--with-key/--without-key',
+              default=True,
+              help=("Formats the output with the yaml key name. "
+                    "--without-key cannot be used with multiple key names."))
 @click.argument('name', nargs=-1)
-def get(session, text, name):
+def get(session, text, with_key, name):
+    if not with_key and len(name) > 1:
+        raise click.ClickException(
+            "Cannot use --without-key when specifying multiple key names.")
+
     result = {}
     for key in name:
         secret = vault_python_api.get_secret(session=session.session,
@@ -102,8 +125,12 @@ def get(session, text, name):
         if text:
             click.echo(secret)
             continue
-        if secret:
-            result[key] = secret
+        nested_secret = nested_keys(key, secret)
+        if with_key:
+            result.update(nested_secret)
+        else:
+            result = secret
+            break
     if result and not text:
         click.echo(yaml.dump(result,
                              default_flow_style=False,

--- a/vault_cli/vault.py
+++ b/vault_cli/vault.py
@@ -139,11 +139,16 @@ def get(session, text, with_key, name):
 
 @click.command("set")
 @click.pass_obj
+@click.option('--yaml', 'format_yaml', is_flag=True)
 @click.argument('name')
 @click.argument('value', nargs=-1)
-def set_(session, name, value):
+def set_(session, format_yaml, name, value):
     if len(value) == 1:
         value = value[0]
+
+    if format_yaml:
+        value = yaml.safe_load(value)
+
     vault_python_api.put_secret(session=session.session,
                                 url=session.full_url(name),
                                 data={'value': value})

--- a/vault_cli/vault.py
+++ b/vault_cli/vault.py
@@ -107,7 +107,10 @@ def nested_keys(path, value):
 
 @click.command()
 @click.pass_obj
-@click.option('--text', is_flag=True)
+@click.option('--text',
+              is_flag=True,
+              help=("--text implies --without-key. Returns the value in "
+                    "plain text format instead of yaml."))
 @click.option('--with-key/--without-key',
               default=True,
               help=("Formats the output with the yaml key name. "


### PR DESCRIPTION
Add:
- `--yaml` option on `set` command
- `--with-key/--without-key` on `get` command
- Display `get a/b/c` in yaml formatted value