### PR TITLE
Session verify

### DIFF
--- a/vault_cli/vault.py
+++ b/vault_cli/vault.py
@@ -40,7 +40,7 @@ def read_config_file(file_path):
     try:
         with open(os.path.expanduser(file_path), "r") as f:
             config = yaml.safe_load(f)
-    except FileNotFoundError:
+    except IOError:
         return {}
     config.pop("config", None)
 
@@ -85,9 +85,10 @@ def get_all(session, path):
         url=url)
 
     if result:
-        click.echo(yaml.dump(result,
-                             default_flow_style=False,
-                             explicit_start=True))
+        click.echo(yaml.safe_dump(
+            result,
+            default_flow_style=False,
+            explicit_start=True))
 
 
 def nested_keys(path, value):
@@ -135,9 +136,10 @@ def get(session, text, with_key, name):
             result = secret
             break
     if result and not text:
-        click.echo(yaml.dump(result,
-                             default_flow_style=False,
-                             explicit_start=True))
+        click.echo(yaml.safe_dump(
+            result,
+            default_flow_style=False,
+            explicit_start=True))
 
 
 @click.command("set")

--- a/vault_cli/vault_python_api.py
+++ b/vault_cli/vault_python_api.py
@@ -10,6 +10,21 @@ except ImportError:
     from urlparse import urljoin
 
 
+class Session(requests.Session):
+    """A wrapper for requests.Session to override 'verify' property, ignoring
+    REQUESTS_CA_BUNDLE environment variable.
+
+    This is a workaround for
+    https://github.com/requests/requests/issues/3829
+    """
+    def merge_environment_settings(self, url, proxies, stream, verify,
+                                   *args, **kwargs):
+        if self.verify is False:
+            verify = False
+
+        return super(Session, self).merge_environment_settings(
+            url, proxies, stream, verify, *args, **kwargs)
+
 
 class VaultSession(object):
     def __init__(self, url, verify, base_path,
@@ -63,7 +78,7 @@ def handle_error(response, expected_code=requests.codes.ok):
 
 
 def create_session(verify):
-    session = requests.Session()
+    session = Session()
     session.verify = verify
     return session
 

--- a/vault_cli/vault_python_api.py
+++ b/vault_cli/vault_python_api.py
@@ -3,12 +3,18 @@
 import json
 import requests
 
-from urllib.parse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    # Python 2
+    from urlparse import urljoin
+
 
 
 class VaultSession(object):
     def __init__(self, url, verify, base_path,
-                 certificate=None, token=None, username=None, password_file=None):
+                 certificate=None, token=None, username=None,
+                 password_file=None):
         self.session = create_session(verify)
 
         self.url = urljoin(url, "v1/")
@@ -39,7 +45,7 @@ class VaultSession(object):
 class VaultAPIException(Exception):
 
     def __init__(self, status_code, body, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(VaultAPIException, self).__init__(*args, **kwargs)
         self.status_code = status_code
         try:
             self.error = '\n'.join(json.loads(body)['errors'])

--- a/vault_cli/vault_python_api.py
+++ b/vault_cli/vault_python_api.py
@@ -2,6 +2,7 @@
 
 import json
 import requests
+import urllib3
 
 try:
     from urllib.parse import urljoin
@@ -21,6 +22,7 @@ class Session(requests.Session):
                                    *args, **kwargs):
         if self.verify is False:
             verify = False
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         return super(Session, self).merge_environment_settings(
             url, proxies, stream, verify, *args, **kwargs)


### PR DESCRIPTION
* Respect `verify` parameter even when `REQUESTS_BUNDLE_CA` envvar is defined
* Python 2 compat. It's so easy to do and it will help us to integrate it :)
* Disable the **many** warnings when verify is False