### PR TITLE
Add "--token-file" switch/option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Options:
   --verify / --no-verify        Verify HTTPS certificate
   -c, --certificate FILENAME    The certificate to connect to vault
   -t, --token TEXT              The token to connect to Vault
+  -T, --token-file FILENAME     File which contains the token to connect to
+                                Vault
   -u, --username TEXT           The username used for userpass authentication
   -w, --password-file FILENAME  Can read from stdin if "-" is used as
                                 parameter
@@ -117,6 +119,8 @@ their corresponding values:
 ---
 username: my_username
 password-file: ~/.vault-password
+# or
+token-file: ~/.vault-token
 url: https://vault.mydomain:8200
 verify: no
 base-path: project/

--- a/vault_cli/vault.py
+++ b/vault_cli/vault.py
@@ -24,6 +24,8 @@ CONTEXT_SETTINGS = {'help_option_names': ['-h', '--help']}
 @click.option('--certificate', '-c', type=click.File('rb'),
               help='The certificate to connect to vault')
 @click.option('--token', '-t', help='The token to connect to Vault')
+@click.option('--token-file', '-T', type=click.File('rb'),
+              help='File which contains the token to connect to Vault')
 @click.option('--username', '-u',
               help='The username used for userpass authentication')
 @click.option('--password-file', '-w', type=click.File('rb'),
@@ -54,6 +56,7 @@ def read_config_file(file_path):
 
     _open_file(config, "certificate")
     _open_file(config, "password_file")
+    _open_file(config, "token_file")
 
     return config
 

--- a/vault_cli/vault_python_api.py
+++ b/vault_cli/vault_python_api.py
@@ -31,11 +31,14 @@ class Session(requests.Session):
 class VaultSession(object):
     def __init__(self, url, verify, base_path,
                  certificate=None, token=None, username=None,
-                 password_file=None):
+                 password_file=None, token_file=None):
         self.session = create_session(verify)
 
         self.url = urljoin(url, "v1/")
         self.base_path = base_path
+
+        if token_file:
+            token = token_file.read().decode("utf-8").strip()
 
         if token:
             self.session.headers.update({'X-Vault-Token': token})


### PR DESCRIPTION
Add `--token-file` switch/option.

Tested:
```
root@vault:~# VAULT_ADDR=http://127.0.0.1:8200 vault kv put secret/hello value=world # create secret

pilou@laptop:~$ vault -T tokenfile --url http://172.18.0.2:8200 get secret/hello # test short form
--- world
...

pilou@laptop:~$ vault --token-file tokenfile --url http://172.18.0.2:8200 get secret/hello # test long form
--- world
...

pilou@laptop:~$ vault -t plop -T tokenfile --url http://172.18.0.2:8200 get secret/hello # test switch precedence
--- world
...

pilou@laptop:~$ vault --token-file /not/existing/path --url http://172.18.0.2:8200 get secret/hello # test non existing path
Usage: vault [OPTIONS] COMMAND [ARGS]...

Error: Invalid value for "--token-file" / "-T": Could not open file: /not/existing/path: No such file or directory

pilou@laptop:~$ vault --token-file /tmp/tokenfile --url http://172.18.0.2:8200 get secret/hello # test wrong token value
Traceback (most recent call last):
[...]
vault_cli.vault_python_api.VaultAPIException: status=403 error="permission denied"
```