### PR TITLE
Handle trailing slash in path

### DIFF
--- a/vault_cli/vault_python_api.py
+++ b/vault_cli/vault_python_api.py
@@ -58,7 +58,7 @@ class VaultSession(object):
     def full_url(self, path=None):
         url = urljoin(self.url, self.base_path)
         if path:
-            return urljoin(url, path)
+            return '/'.join(x.strip('/') for x in (url, path))
         return url
 
 


### PR DESCRIPTION
`urljoin` behaves like `os.path.join`:
```
>>> from urllib.parse import urljoin
>>> urljoin("http://host.test:8200/v1/base", "path")
'http://host.test:8200/v1/path'
>>> urljoin("host.test:8200/v1/base/", "path")
'http://host.test:8200/v1/base/path'
```

Closes #9 

Not sure if [this call](https://github.com/peopledoc/vault-cli/blob/654a6575ee5005802f2c7e17abf86d6f4f33f58d/vault_cli/vault_python_api.py#L169) to `urljoin` is ok or not.