### PR TITLE
Fix Python 2 compatibility: use absolute imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+CHANGELOG
+=========
+
+* [BUGFIX] Fix Python 2 compatibility (#20)

--- a/vault_cli/requests.py
+++ b/vault_cli/requests.py
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import absolute_import
+
 import requests
 import urllib3
 


### PR DESCRIPTION
Exception was:

     Traceback (most recent call last):
      File "vault/bin/vault", line 11, in <module>
        sys.exit(main())
      File "vault/local/lib/python2.7/site-packages/vault_cli/vault.py", line 224, in main
        return cli(default_map=config)
      File "vault/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
        return self.main(*args, **kwargs)
      File "vault/local/lib/python2.7/site-packages/click/core.py", line 697, in main
        rv = self.invoke(ctx)
      File "vault/local/lib/python2.7/site-packages/click/core.py", line 1063, in invoke
        Command.invoke(self, ctx)
      File "vault/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "vault/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
        return callback(*args, **kwargs)
      File "vault/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
        return f(get_current_context(), *args, **kwargs)
      File "vault/local/lib/python2.7/site-packages/vault_cli/vault.py", line 59, in cli
        from vault_cli import requests as backend_module
      File "vault/local/lib/python2.7/site-packages/vault_cli/requests.py", line 31, in <module>
        class Session(requests.Session):
    AttributeError: 'module' object has no attribute 'Session'