### PR TITLE
Update debian's changelog and add README

### DIFF
--- a/debian/README
+++ b/debian/README
@@ -1,0 +1,7 @@
+How to release
+==============
+
+1. Create a new changelog entry with the new version of the package (use `dch`)
+2. sudo pbuilder --update
+3. sudo pdebuild
+4. Your package should be available in /var/cache/pbuilder/results

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vault-cli (0.3.0) unstable; urgency=medium
+
+  * New release
+
+ -- Mickaël Guérin <mickael.guerin@people-doc.com>  Fri, 05 Oct 2018 14:21:05 +0200
+
 vault-cli (0.1.0) unstable; urgency=medium
 
   * Initial release

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vault-cli
 Section: net
 Priority: optional
 Maintainer: Mickaël Guérin <mickael.guerin@people-doc.com>
-Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools
+Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, python3-yaml
 Standards-Version: 4.1.2
 Homepage: https://github.com/peopledoc/vault-cli
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
I have used this changes to build a package for vault-cli 0.3.0 and
upload it to the stretch-peopledoc repository