### PR TITLE
Add extra dependencies "sni"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,11 @@ test =
     pytest-cov
     pytest-click
 
+# Backport of SNI support for old OSes (like Debian Wheezy)
+sni =
+    pyOpenSSL
+    idna
+
 [bdist_wheel]
 universal = 1
 


### PR DESCRIPTION
use
```
pip install 'vault-cli[sni]'
```

when using vault-cli with old OSes