### PR TITLE
Linting, mypy etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 htmlcov
 .tox
 *.pyc
+/.vault-token
+/.vault.yml
+/.mypy_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,27 @@ services:
 matrix:
   include:
 
+  - python: 2.7
+    env: TOX_ENV=py27-unit-tests COVERAGE_FLAG=unit
+
+  - python: 2.7
+    env: TOX_ENV=py27-integration-tests COVERAGE_FLAG=integration
+
   - python: 3.6
     env: TOX_ENV=py36-unit-tests COVERAGE_FLAG=unit
 
   - python: 3.6
     env: TOX_ENV=py36-integration-tests COVERAGE_FLAG=integration
 
-  - python: 2.7
-    env: TOX_ENV=py27-unit-tests COVERAGE_FLAG=unit
+  - python: 3.7
+    env: TOX_ENV=py37-unit-tests COVERAGE_FLAG=unit
 
-  - python: 2.7
-    env: TOX_ENV=py27-integration-tests COVERAGE_FLAG=integration
+  - python: 3.7
+    env: TOX_ENV=py37-integration-tests COVERAGE_FLAG=integration
+
+  - python: 3.7
+    env: TOX_ENV=check-lint
+
 
 before_install:
   - "if [ $COVERAGE_FLAG = integration ]; then ./dev-env; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ services:
 matrix:
   include:
 
-  - python: 2.7
-    env: TOX_ENV=py27-unit-tests COVERAGE_FLAG=unit
-
-  - python: 2.7
-    env: TOX_ENV=py27-integration-tests COVERAGE_FLAG=integration
-
   - python: 3.6
     env: TOX_ENV=py36-unit-tests COVERAGE_FLAG=unit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # Config file for automatic testing at travis-ci.org
 language: python
 cache: pip
-
+sudo: required
+dist: xenial
 services:
   - docker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e .[hvac,dev,test,lint]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,11 @@ classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 
 [options]
 zip_safe = True
@@ -40,6 +42,8 @@ hvac =
 
 dev =
     twine
+    black
+    isort
 
 test =
     pytest
@@ -48,8 +52,24 @@ test =
     pytest-cov
     pytest-click
 
+lint =
+    mypy
+    flake8
+    black
+    isort
+
+
 [bdist_wheel]
 universal = 1
+
+
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+not_skip = __init__.py
 
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,6 @@ install_requires =
     requests
     Click>=7.0
     pyyaml
-    backports.functools_lru_cache; python_version<"3.2"
-    # SNI support
-    pyOpenSSL; python_version<"2.7.9"
-    idna; python_version<"2.7.9"
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,3 +70,14 @@ not_skip = __init__.py
 
 [tool:pytest]
 addopts = --cov-report term-missing --cov-branch --cov-report html --cov-report term --cov=vault_cli -vv
+
+
+[mypy-backports.functools_lru_cache.*,setuptools.*,urllib3.*,hvac.*]
+ignore_missing_imports = True
+
+
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 import vault_cli
 from vault_cli import cli
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,9 +1,8 @@
 import os
 
 import pytest
-
-from vault_cli import cli
 import vault_cli
+from vault_cli import cli
 
 
 def call(cli_runner, *args):
@@ -27,11 +26,13 @@ def test_integration_cli(cli_runner):
 
     assert call(cli_runner, ["list", "c"]).output == "d\n"
 
-    assert call(cli_runner, ["get-all", ""]).output == ("""---
+    assert call(cli_runner, ["get-all", ""]).output == (
+        """---
 a: b
 c:
   d: e
-""")
+"""
+    )
 
     call(cli_runner, ["delete", "a"])
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 import vault_cli
 from vault_cli import cli
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,6 @@
-import pytest
 import yaml
 
+import pytest
 from vault_cli import cli, client
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,6 @@
+import pytest
 import yaml
 
-import pytest
 from vault_cli import cli, client
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,8 +1,7 @@
 import yaml
-import pytest
 
-from vault_cli import cli
-from vault_cli import client
+import pytest
+from vault_cli import cli, client
 
 
 class FakeClient(client.VaultClientBase):
@@ -26,8 +25,7 @@ class FakeClient(client.VaultClientBase):
 @pytest.fixture
 def backend(mocker):
     backend = FakeClient()
-    mocker.patch("vault_cli.requests.RequestsVaultClient",
-                 return_value=backend)
+    mocker.patch("vault_cli.requests.RequestsVaultClient", return_value=backend)
     yield backend
 
 
@@ -40,20 +38,32 @@ def test_bad_backend(cli_runner, backend):
 
 def test_options(cli_runner, mocker):
     func = mocker.patch("vault_cli.client.get_client_from_kwargs")
-    mocker.patch("vault_cli.settings.read_file",
-                 side_effect=lambda x: "content of {}".format(x))
-    result = cli_runner.invoke(cli.cli, [
-        "--backend", "requests",
-        "--base-path", "bla",
-        "--ca-bundle", "yay",
-        "--certificate-file", "a",
-        "--password-file", "b",
-        "--token-file", "c",
-        "--url", "https://foo",
-        "--username", "user",
-        "--verify",
-        "list"
-    ])
+    mocker.patch(
+        "vault_cli.settings.read_file", side_effect=lambda x: "content of {}".format(x)
+    )
+    result = cli_runner.invoke(
+        cli.cli,
+        [
+            "--backend",
+            "requests",
+            "--base-path",
+            "bla",
+            "--ca-bundle",
+            "yay",
+            "--certificate-file",
+            "a",
+            "--password-file",
+            "b",
+            "--token-file",
+            "c",
+            "--url",
+            "https://foo",
+            "--username",
+            "user",
+            "--verify",
+            "list",
+        ],
+    )
 
     assert result.exit_code == 0, result.output
     _, kwargs = func.call_args
@@ -104,7 +114,7 @@ def test_get_all(cli_runner, backend):
 
     result = cli_runner.invoke(cli.cli, ["get-all", "a"])
 
-    assert yaml.safe_load(result.output) == {'a': {'baz': 'bar', 'foo': 'bar'}}
+    assert yaml.safe_load(result.output) == {"a": {"baz": "bar", "foo": "bar"}}
     assert result.exit_code == 0
 
 
@@ -133,8 +143,9 @@ def test_set_stdin(cli_runner, backend):
 
 def test_set_stdin_yaml(cli_runner, backend):
     # Just checking that yaml and stdin are not incompatible
-    result = cli_runner.invoke(cli.cli, ["set", "--stdin", "--yaml", "a"],
-                               input=yaml.safe_dump({"b": "c"}))
+    result = cli_runner.invoke(
+        cli.cli, ["set", "--stdin", "--yaml", "a"], input=yaml.safe_dump({"b": "c"})
+    )
 
     assert result.exit_code == 0
     assert backend.set == ["a", {"b": "c"}]
@@ -181,45 +192,48 @@ def test_load_config_no_config(mocker):
     assert ctx.default_map == {}
 
 
-@pytest.mark.parametrize("value, expected", [
-    ("bla", ["bla"]),
-    (None, ["./.vault.yml", "~/.vault.yml", "/etc/vault.yml"]),
-])
+@pytest.mark.parametrize(
+    "value, expected",
+    [("bla", ["bla"]), (None, ["./.vault.yml", "~/.vault.yml", "/etc/vault.yml"])],
+)
 def test_load_config(mocker, value, expected):
     ctx = mocker.Mock()
-    build = mocker.patch("vault_cli.settings.build_config_from_files",
-                         return_value={"a": "b"})
+    build = mocker.patch(
+        "vault_cli.settings.build_config_from_files", return_value={"a": "b"}
+    )
     cli.load_config(ctx, None, value)
 
     assert ctx.default_map == {"a": "b"}
     build.assert_called_with(*expected)
 
 
-@pytest.mark.parametrize("config, environ, expected", [
-    # Empty does not crash or what
-    ({}, {}, {}),
-    # Irrelevant keys are not copied over
-    ({"a": "b"}, {"c", "d"}, {}),
-
-    # Relevant keys is copied from first dict
-    ({"password": "e"}, {}, {"password": "e"}),
-    ({"token": "f"}, {}, {"token": "f"}),
-    ({"certificate": "g"}, {}, {"certificate": "g"}),
-
-    # Relevant keys is copied from second dict
-    ({}, {"VAULT_CLI_PASSWORD": "h"}, {"password": "h"}),
-    ({}, {"VAULT_CLI_TOKEN": "i"}, {"token": "i"}),
-    ({}, {"VAULT_CLI_CERTIFICATE": "j"}, {"certificate": "j"}),
-
-    # Second dict has priority
-    ({"password": "l"}, {"VAULT_CLI_PASSWORD": "m"}, {"password": "m"}),
-    ({"token": "n"}, {"VAULT_CLI_TOKEN": "o"}, {"token": "o"}),
-    ({"certificate": "p"}, {"VAULT_CLI_CERTIFICATE": "q"}, {"certificate": "q"}),
-
-    # Both dict are used
-    ({"password": "r"}, {"VAULT_CLI_CERTIFICATE": "s"},
-     {"password": "r", "certificate": "s"}),
-])
+@pytest.mark.parametrize(
+    "config, environ, expected",
+    [
+        # Empty does not crash or what
+        ({}, {}, {}),
+        # Irrelevant keys are not copied over
+        ({"a": "b"}, {"c", "d"}, {}),
+        # Relevant keys is copied from first dict
+        ({"password": "e"}, {}, {"password": "e"}),
+        ({"token": "f"}, {}, {"token": "f"}),
+        ({"certificate": "g"}, {}, {"certificate": "g"}),
+        # Relevant keys is copied from second dict
+        ({}, {"VAULT_CLI_PASSWORD": "h"}, {"password": "h"}),
+        ({}, {"VAULT_CLI_TOKEN": "i"}, {"token": "i"}),
+        ({}, {"VAULT_CLI_CERTIFICATE": "j"}, {"certificate": "j"}),
+        # Second dict has priority
+        ({"password": "l"}, {"VAULT_CLI_PASSWORD": "m"}, {"password": "m"}),
+        ({"token": "n"}, {"VAULT_CLI_TOKEN": "o"}, {"token": "o"}),
+        ({"certificate": "p"}, {"VAULT_CLI_CERTIFICATE": "q"}, {"certificate": "q"}),
+        # Both dict are used
+        (
+            {"password": "r"},
+            {"VAULT_CLI_CERTIFICATE": "s"},
+            {"password": "r", "certificate": "s"},
+        ),
+    ],
+)
 def test_extract_special_args(config, environ, expected):
     result = cli.extract_special_args(config, environ)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,12 +1,14 @@
 import pytest
-
 from vault_cli import client
 
 
-@pytest.mark.parametrize("backend, mock", [
-    ("requests", "vault_cli.requests.RequestsVaultClient"),
-    ("hvac", "vault_cli.hvac.HVACVaultClient"),
-])
+@pytest.mark.parametrize(
+    "backend, mock",
+    [
+        ("requests", "vault_cli.requests.RequestsVaultClient"),
+        ("hvac", "vault_cli.hvac.HVACVaultClient"),
+    ],
+)
 def test_get_client_from_kwargs(mocker, backend, mock):
     c = mocker.patch(mock)
     client.get_client_from_kwargs(backend, a=1)
@@ -27,8 +29,9 @@ def test_get_client_from_kwargs_bad(mocker):
 
 
 def test_get_client(mocker):
-    mocker.patch("vault_cli.settings.build_config_from_files",
-                 return_value={"url": "yay"})
+    mocker.patch(
+        "vault_cli.settings.build_config_from_files", return_value={"url": "yay"}
+    )
     backend = mocker.Mock()
 
     c = client.get_client(backend=backend, yo=True)
@@ -37,40 +40,47 @@ def test_get_client(mocker):
     assert backend.return_value == c
 
 
-@pytest.mark.parametrize("error, expected", [
-    ("oh no", '''status=404 error="oh no"'''),
-    ('''{"errors": ["damn", "gosh"]}''', '''status=404 error="damn\ngosh"'''),
-])
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        ("oh no", '''status=404 error="oh no"'''),
+        ("""{"errors": ["damn", "gosh"]}""", '''status=404 error="damn\ngosh"'''),
+    ],
+)
 def test_vault_api_exception(error, expected):
     exc_str = str(client.VaultAPIException(404, error))
 
     assert exc_str == expected
 
 
-@pytest.mark.parametrize("func, args", [
-    ("_init_session", "url verify"),
-    ("_authenticate_token", "token"),
-    ("_authenticate_certificate", "certificate"),
-    ("_authenticate_userpass", "username password"),
-    ("list_secrets", "path"),
-    ("get_secret", "path"),
-    ("delete_secret", "path"),
-    ("set_secret", "path value"),
-])
+@pytest.mark.parametrize(
+    "func, args",
+    [
+        ("_init_session", "url verify"),
+        ("_authenticate_token", "token"),
+        ("_authenticate_certificate", "certificate"),
+        ("_authenticate_userpass", "username password"),
+        ("list_secrets", "path"),
+        ("get_secret", "path"),
+        ("delete_secret", "path"),
+        ("set_secret", "path value"),
+    ],
+)
 def test_vault_client_base_not_implemented(func, args):
     class TestVaultClient(client.VaultClientBase):
         def __init__(self):
             pass
+
     c = TestVaultClient()
 
     with pytest.raises(NotImplementedError):
         getattr(c, func)(**{name: None for name in args.split()})
 
 
-@pytest.mark.parametrize("path, value, expected", [
-    ('test', 'foo', {'test': 'foo'}),
-    ('test/bla', 'foo', {'test': {'bla': 'foo'}}),
-])
+@pytest.mark.parametrize(
+    "path, value, expected",
+    [("test", "foo", {"test": "foo"}), ("test/bla", "foo", {"test": {"bla": "foo"}})],
+)
 def test_nested_keys(path, value, expected):
     assert client.nested_keys(path, value) == expected
 
@@ -85,21 +95,28 @@ def test_vault_client_base_call_init_session():
         def _authenticate_token(self, *args, **kwargs):
             pass
 
-    TestVaultClient(verify=False, url="yay", token="go",
-                    base_path=None, certificate=None, username=None,
-                    password=None, ca_bundle=None)
+    TestVaultClient(
+        verify=False,
+        url="yay",
+        token="go",
+        base_path=None,
+        certificate=None,
+        username=None,
+        password=None,
+        ca_bundle=None,
+    )
 
     assert called_with == {"verify": False, "url": "yay"}
 
 
-@pytest.mark.parametrize("test_kwargs, expected", [
-    ({"token": "yay"}, ["token", "yay"]),
-    (
-        {"username": "a", "password": "b"},
-        ["userpass", "a", "b"]
-    ),
-    ({"certificate": "cert"}, ["certificate", "cert"]),
-])
+@pytest.mark.parametrize(
+    "test_kwargs, expected",
+    [
+        ({"token": "yay"}, ["token", "yay"]),
+        ({"username": "a", "password": "b"}, ["userpass", "a", "b"]),
+        ({"certificate": "cert"}, ["certificate", "cert"]),
+    ],
+)
 def test_vault_client_base_authenticate(test_kwargs, expected):
     auth_params = []
 
@@ -116,40 +133,47 @@ def test_vault_client_base_authenticate(test_kwargs, expected):
         def _authenticate_userpass(self, username, password):
             auth_params.extend(["userpass", username, password])
 
-    kwargs = {"token": None,
-              "username": None, "password": None,
-              "certificate": None}
+    kwargs = {"token": None, "username": None, "password": None, "certificate": None}
     kwargs.update(test_kwargs)
-    TestVaultClient(verify=False, url=None, base_path=None,
-                    ca_bundle=None, **kwargs)
+    TestVaultClient(verify=False, url=None, base_path=None, ca_bundle=None, **kwargs)
 
     assert auth_params == expected
 
 
 def test_vault_client_base_username_without_password():
-
     class TestVaultClient(client.VaultClientBase):
         def _init_session(self, **kwargs):
             pass
 
     with pytest.raises(ValueError):
-        TestVaultClient(username="yay", password=None,
-                        verify=False, url="yay", token=None,
-                        base_path=None, certificate=None,
-                        ca_bundle=None)
+        TestVaultClient(
+            username="yay",
+            password=None,
+            verify=False,
+            url="yay",
+            token=None,
+            base_path=None,
+            certificate=None,
+            ca_bundle=None,
+        )
 
 
 def test_vault_client_base_no_auth():
-
     class TestVaultClient(client.VaultClientBase):
         def _init_session(self, **kwargs):
             pass
 
     with pytest.raises(ValueError):
-        TestVaultClient(username=None, password=None,
-                        verify=False, url="yay", token=None,
-                        base_path=None, certificate=None,
-                        ca_bundle=None)
+        TestVaultClient(
+            username=None,
+            password=None,
+            verify=False,
+            url="yay",
+            token=None,
+            base_path=None,
+            certificate=None,
+            ca_bundle=None,
+        )
 
 
 def test_vault_client_set_ca_bundle(mocker):
@@ -161,9 +185,16 @@ def test_vault_client_set_ca_bundle(mocker):
             session_kwargs.update(kwargs)
 
     with pytest.raises(ValueError):
-        TestVaultClient(verify=True, ca_bundle="yay",
-                        username=None, password=None, url=None,
-                        token=None, base_path=None, certificate=None)
+        TestVaultClient(
+            verify=True,
+            ca_bundle="yay",
+            username=None,
+            password=None,
+            url=None,
+            token=None,
+            base_path=None,
+            certificate=None,
+        )
 
     assert session_kwargs["verify"] == "yay"
 
@@ -177,9 +208,16 @@ def test_vault_client_set_ca_bundle_no_bundle():
             session_kwargs.update(kwargs)
 
     with pytest.raises(ValueError):
-        TestVaultClient(verify=True, ca_bundle=None,
-                        username=None, password=None, url=None,
-                        token=None, base_path=None, certificate=None)
+        TestVaultClient(
+            verify=True,
+            ca_bundle=None,
+            username=None,
+            password=None,
+            url=None,
+            token=None,
+            base_path=None,
+            certificate=None,
+        )
 
     assert session_kwargs["verify"] is True
 
@@ -193,58 +231,51 @@ def test_vault_client_set_ca_bundle_no_verify():
             session_kwargs.update(kwargs)
 
     with pytest.raises(ValueError):
-        TestVaultClient(verify=False, ca_bundle="yay",
-                        username=None, password=None, url=None,
-                        token=None, base_path=None, certificate=None)
+        TestVaultClient(
+            verify=False,
+            ca_bundle="yay",
+            username=None,
+            password=None,
+            url=None,
+            token=None,
+            base_path=None,
+            certificate=None,
+        )
 
     assert session_kwargs["verify"] is False
 
 
 def test_vault_client_base_get_recursive_secrets():
-
     class TestVaultClient(client.VaultClientBase):
         def __init__(self):
             pass
 
         def list_secrets(self, path):
-            return {
-                "": ["a", "b/"],
-                "b": ["c"]
-            }[path]
+            return {"": ["a", "b/"], "b": ["c"]}[path]
 
         def get_secret(self, path):
-            return {
-                "a": "secret-a",
-                "b/c": "secret-bc",
-            }[path]
+            return {"a": "secret-a", "b/c": "secret-bc"}[path]
 
     result = TestVaultClient()._get_recursive_secrets("")
 
-    assert result == {'a': 'secret-a', 'b': {'c': 'secret-bc'}}
+    assert result == {"a": "secret-a", "b": {"c": "secret-bc"}}
 
 
 def test_vault_client_base_get_all():
-
     class TestVaultClient(client.VaultClientBase):
         def __init__(self):
             pass
 
         def list_secrets(self, path):
-            return {
-                "": ["a/", "b"],
-                "a": ["c"]
-            }[path]
+            return {"": ["a/", "b"], "a": ["c"]}[path]
 
         def get_secret(self, path):
-            return {
-                "a/c": "secret-ac",
-                "b": "secret-b",
-            }[path]
+            return {"a/c": "secret-ac", "b": "secret-b"}[path]
 
     result = TestVaultClient().get_all(["a", ""])
 
-    assert result == {'a': {'c': 'secret-ac'}, 'b': 'secret-b'}
+    assert result == {"a": {"c": "secret-ac"}, "b": "secret-b"}
 
     result = TestVaultClient().get_all(["a"])
 
-    assert result == {'a': {'c': 'secret-ac'}}
+    assert result == {"a": {"c": "secret-ac"}}

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,4 +1,5 @@
 import pytest
+
 from vault_cli import client
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,4 @@
 import pytest
-
 from vault_cli import client
 
 

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -1,5 +1,4 @@
 import pytest
-
 from vault_cli import client
 
 
@@ -22,9 +21,11 @@ def get_client(backend, **additional_kwargs):
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_token(requests_mock, backend):
     client_obj = get_client(backend)
-    requests_mock.get("http://vault:8000/v1/bla/a",
-                      request_headers={'X-Vault-Token': 'tok'},
-                      json={"data": {"value": "b"}})
+    requests_mock.get(
+        "http://vault:8000/v1/bla/a",
+        request_headers={"X-Vault-Token": "tok"},
+        json={"data": {"value": "b"}},
+    )
 
     client_obj.get_secret("a")
 
@@ -33,40 +34,41 @@ def test_token(requests_mock, backend):
 
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_userpass(requests_mock, backend):
-    requests_mock.post("http://vault:8000/v1/auth/userpass/login/myuser",
-                       json={"auth": {"client_token": "newtok"}})
+    requests_mock.post(
+        "http://vault:8000/v1/auth/userpass/login/myuser",
+        json={"auth": {"client_token": "newtok"}},
+    )
 
     # Initialize a client, check that we get a token
     client_obj = get_client(
-        backend=backend,
-        token=None,
-        username="myuser",
-        password="pass",
+        backend=backend, token=None, username="myuser", password="pass"
     )
 
     # Check that the token is used
-    requests_mock.get("http://vault:8000/v1/bla/a",
-                      request_headers={'X-Vault-Token': 'newtok'},
-                      json={"data": {"value": "b"}})
+    requests_mock.get(
+        "http://vault:8000/v1/bla/a",
+        request_headers={"X-Vault-Token": "newtok"},
+        json={"data": {"value": "b"}},
+    )
     assert client_obj.get_secret("a") == "b"
 
     # Check that we sent the right pasword
-    assert requests_mock.request_history[0].json() == {'password': 'pass'}
+    assert requests_mock.request_history[0].json() == {"password": "pass"}
 
 
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_get_secret(requests_mock, backend):
     client_obj = get_client(backend)
-    requests_mock.get("http://vault:8000/v1/bla/a",
-                      json={"data": {"value": "b"}})
+    requests_mock.get("http://vault:8000/v1/bla/a", json={"data": {"value": "b"}})
     assert client_obj.get_secret("a") == "b"
 
 
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_get_secret_not_found(requests_mock, backend):
     client_obj = get_client(backend)
-    requests_mock.get("http://vault:8000/v1/bla/a", status_code=404,
-                      json={"errors": ["Not found"]})
+    requests_mock.get(
+        "http://vault:8000/v1/bla/a", status_code=404, json={"errors": ["Not found"]}
+    )
     with pytest.raises(client.VaultAPIException):
         assert client_obj.get_secret("a")
 
@@ -74,8 +76,7 @@ def test_get_secret_not_found(requests_mock, backend):
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_get_secret_no_verify(requests_mock, backend):
     client_obj = get_client(backend, verify=False)
-    requests_mock.get("http://vault:8000/v1/bla/a",
-                      json={"data": {"value": "b"}})
+    requests_mock.get("http://vault:8000/v1/bla/a", json={"data": {"value": "b"}})
     assert client_obj.get_secret("a") == "b"
     assert requests_mock.last_request.verify is False
 
@@ -83,26 +84,31 @@ def test_get_secret_no_verify(requests_mock, backend):
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_list_secrets(requests_mock, backend):
     client_obj = get_client(backend)
-    requests_mock.get("http://vault:8000/v1/bla/a?list=True",
-                      json={"data": {"keys": ["b"]}})
+    requests_mock.get(
+        "http://vault:8000/v1/bla/a?list=True", json={"data": {"keys": ["b"]}}
+    )
     assert client_obj.list_secrets("a") == ["b"]
 
 
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_list_secrets_empty(requests_mock, backend):
     client_obj = get_client(backend)
-    requests_mock.get("http://vault:8000/v1/bla/a?list=True",
-                      status_code=404,
-                      json={"errors": ["not found"]})
+    requests_mock.get(
+        "http://vault:8000/v1/bla/a?list=True",
+        status_code=404,
+        json={"errors": ["not found"]},
+    )
     assert client_obj.list_secrets("a") == []
 
 
 @pytest.mark.parametrize("backend", ["requests", "hvac"])
 def test_list_secrets_other_error(requests_mock, backend):
     client_obj = get_client(backend)
-    requests_mock.get("http://vault:8000/v1/bla/a?list=True",
-                      status_code=500,
-                      json={"errors": ["not found"]})
+    requests_mock.get(
+        "http://vault:8000/v1/bla/a?list=True",
+        status_code=500,
+        json={"errors": ["not found"]},
+    )
 
     with pytest.raises(Exception):
         client_obj.list_secrets("a")
@@ -126,4 +132,4 @@ def test_set_secret(requests_mock, backend):
     client_obj.set_secret("a", "b")
 
     assert requests_mock.called
-    assert requests_mock.request_history[0].json() == {'value': 'b'}
+    assert requests_mock.request_history[0].json() == {"value": "b"}

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -1,4 +1,5 @@
 import pytest
+
 from vault_cli import client
 
 

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -1,5 +1,4 @@
 import pytest
-
 from vault_cli import client
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,4 @@
-from vault_cli import __main__
-from vault_cli import cli
+from vault_cli import __main__, cli
 
 
 def test_main():

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import io
 
 import pytest
-
 from vault_cli import settings
 
 
@@ -19,8 +18,7 @@ def test_read_config_file(tmpdir):
 
 
 def test_dash_to_underscores():
-    result = settings.dash_to_underscores(
-        {"a": "b", "c_d": "e_f", "g-h": "i-j"})
+    result = settings.dash_to_underscores({"a": "b", "c_d": "e_f", "g-h": "i-j"})
     expected = {"a": "b", "c_d": "e_f", "g_h": "i-j"}
     assert result == expected
 
@@ -32,15 +30,17 @@ def test_read_all_files_no_file():
 
 def test_read_all_files(tmpdir):
     token_path = str(tmpdir.join("token"))
-    open(token_path, "wb").write(b'yay')
+    open(token_path, "wb").write(b"yay")
     certificate_path = str(tmpdir.join("certificate"))
-    open(certificate_path, "wb").write(b'yo')
+    open(certificate_path, "wb").write(b"yo")
     password_path = str(tmpdir.join("password"))
-    open(password_path, "wb").write(b'aaa')
+    open(password_path, "wb").write(b"aaa")
 
-    d = {"token_file": token_path,
-         "certificate_file": certificate_path,
-         "password_file": password_path}
+    d = {
+        "token_file": token_path,
+        "certificate_file": certificate_path,
+        "password_file": password_path,
+    }
     expected = {"token": "yay", "certificate": "yo", "password": "aaa"}
     assert settings.read_all_files(d) == expected
 
@@ -57,10 +57,10 @@ def test_read_file_stdin(mocker):
 def test_build_config_from_files(mocker):
     settings.build_config_from_files.cache_clear()
     config_file = {"test-a": "b"}
-    mocker.patch("vault_cli.settings.read_config_file",
-                 return_value=config_file)
-    read_all_files = mocker.patch("vault_cli.settings.read_all_files",
-                                  side_effect=lambda x: x)
+    mocker.patch("vault_cli.settings.read_config_file", return_value=config_file)
+    read_all_files = mocker.patch(
+        "vault_cli.settings.read_all_files", side_effect=lambda x: x
+    )
 
     result = settings.build_config_from_files("a")
 
@@ -71,8 +71,7 @@ def test_build_config_from_files(mocker):
 
 def test_build_config_from_files_no_files(mocker):
     settings.build_config_from_files.cache_clear()
-    mocker.patch("vault_cli.settings.read_config_file",
-                 return_value=None)
+    mocker.patch("vault_cli.settings.read_config_file", return_value=None)
 
     result = settings.build_config_from_files("a")
 
@@ -80,8 +79,7 @@ def test_build_config_from_files_no_files(mocker):
 
 
 def test_get_vault_options(mocker):
-    mocker.patch("vault_cli.settings.build_config_from_files",
-                 return_value={"a": "b"})
+    mocker.patch("vault_cli.settings.build_config_from_files", return_value={"a": "b"})
     mocker.patch("os.environ", {"VAULT_CLI_URL": "d"})
 
     expected = {"a": "b", "url": "d", "e": "f"}
@@ -89,15 +87,30 @@ def test_get_vault_options(mocker):
     assert settings.get_vault_options(e="f") == expected
 
 
-@pytest.mark.parametrize("value, expected", [
-    ("true", True), ("True", True), ("True", True),
-    ("t", True), ("T", True), ("1", True),
-    ("yes", True), ("YES", True), ("y", True),
-    ("false", False), ("False", False), ("FALSE", False),
-    ("f", False), ("F", False), ("0", False),
-    ("no", False), ("NO", False), ("n", False),
-    ("N", False),
-])
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("True", True),
+        ("t", True),
+        ("T", True),
+        ("1", True),
+        ("yes", True),
+        ("YES", True),
+        ("y", True),
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("f", False),
+        ("F", False),
+        ("0", False),
+        ("no", False),
+        ("NO", False),
+        ("n", False),
+        ("N", False),
+    ],
+)
 def test_load_bool(value, expected):
     assert settings.load_bool(value) == expected
 
@@ -107,14 +120,19 @@ def test_load_bool_wrong():
         assert settings.load_bool("wrong")
 
 
-@pytest.mark.parametrize("value, expected", [
-    ({"COIN": "yay"}, {}),
-    ({"VAULT_CLI_BLA": "yay"}, {}),
-    ({"VAULT_CLI_URL": "yay"}, {"url": "yay"}),
-    ({"VAULT_CLI_BASE_PATH": "yay"}, {"base_path": "yay"}),
-    ({"VAULT_CLI_VERIFY": "t"}, {"verify": True}),
-    ({"VAULT_CLI_VERIFY": "t", "VAULT_CLI_BASE_PATH": "yay"},
-     {"verify": True, "base_path": "yay"}),
-])
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ({"COIN": "yay"}, {}),
+        ({"VAULT_CLI_BLA": "yay"}, {}),
+        ({"VAULT_CLI_URL": "yay"}, {"url": "yay"}),
+        ({"VAULT_CLI_BASE_PATH": "yay"}, {"base_path": "yay"}),
+        ({"VAULT_CLI_VERIFY": "t"}, {"verify": True}),
+        (
+            {"VAULT_CLI_VERIFY": "t", "VAULT_CLI_BASE_PATH": "yay"},
+            {"verify": True, "base_path": "yay"},
+        ),
+    ],
+)
 def test_build_config_from_env(value, expected):
     assert settings.build_config_from_env(value) == expected

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import io
 
 import pytest
+
 from vault_cli import settings
 
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import io
 
 import pytest
-
 from vault_cli import settings
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py36}-{integration,unit}-tests,check-lint
+    {py36,py37}-{integration,unit}-tests,check-lint
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,22 @@ commands =
     pip freeze -l
     unit-tests: pytest tests/unit
     integration-tests: pytest tests/integration
+
+[testenv:check-lint]
+extras =
+    lint
+    hvac
+ignore_errors=true
+commands =
+    mypy vault_cli
+    flake8 .
+    isort --check-only
+    black --check .
+
+
+[testenv:format]
+extras =
+    dev
+commands =
+    isort -y
+    black .

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
 [testenv:format]
 extras =
     dev
+    hvac
 commands =
     isort -y
     black .

--- a/vault_cli/__init__.py
+++ b/vault_cli/__init__.py
@@ -16,8 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from vault_cli.client import get_client
-from vault_cli.client import VaultAPIException
+from vault_cli.client import VaultAPIException, get_client
 
-
-__all__ = ['get_client', 'VaultAPIException']
+__all__ = ["get_client", "VaultAPIException"]

--- a/vault_cli/__main__.py
+++ b/vault_cli/__main__.py
@@ -23,7 +23,7 @@ from vault_cli.cli import main
 
 # Shenanigans for coverage
 def entrypoint(name):
-    if name == '__main__':
+    if name == "__main__":
         main()
 
 

--- a/vault_cli/__main__.py
+++ b/vault_cli/__main__.py
@@ -22,7 +22,7 @@ from vault_cli.cli import main
 
 
 # Shenanigans for coverage
-def entrypoint(name):
+def entrypoint(name: str):
     if name == "__main__":
         main()
 

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -21,13 +21,11 @@ import os
 import click
 import yaml
 
-from vault_cli import client
-from vault_cli import settings
-
+from vault_cli import client, settings
 
 CONTEXT_SETTINGS = {
-    'help_option_names': ['-h', '--help'],
-    'auto_envvar_prefix': settings.ENV_PREFIX
+    "help_option_names": ["-h", "--help"],
+    "auto_envvar_prefix": settings.ENV_PREFIX,
 }
 
 
@@ -47,31 +45,56 @@ def load_config(ctx, param, value):
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.pass_context
-@click.option('--url', '-U', help='URL of the vault instance',
-              default=settings.DEFAULTS['url'])
-@click.option('--verify/--no-verify', default=settings.DEFAULTS['verify'],
-              help='Verify HTTPS certificate')
-@click.option('--ca-bundle', type=click.Path(),
-              help='Location of the bundle containing the server certificate '
-              'to check against.')
-@click.option('--certificate-file', '-c', type=click.Path(),
-              help='Certificate to connect to vault. '
-              'Configuration file can also contain a "certificate" key.')
-@click.option('--token-file', '-T', type=click.Path(),
-              help='File which contains the token to connect to Vault. '
-              'Configuration file can also contain a "token" key.')
-@click.option('--username', '-u',
-              help='Username used for userpass authentication')
-@click.option('--password-file', '-w', type=click.Path(),
-              help='Can read from stdin if "-" is used as parameter. '
-              'Configuration file can also contain a "password" key.')
-@click.option('--base-path', '-b', help='Base path for requests')
-@click.option('--backend', default=settings.DEFAULTS['backend'],
-              help='Name of the backend to use (requests, hvac)')
-@click.option("--config-file", is_eager=True, callback=load_config,
-              help="Config file to use. Use 'no' to disable config file. "
-              "Default value: first of "
-              + ", ".join(settings.CONFIG_FILES), type=click.Path())
+@click.option(
+    "--url", "-U", help="URL of the vault instance", default=settings.DEFAULTS["url"]
+)
+@click.option(
+    "--verify/--no-verify",
+    default=settings.DEFAULTS["verify"],
+    help="Verify HTTPS certificate",
+)
+@click.option(
+    "--ca-bundle",
+    type=click.Path(),
+    help="Location of the bundle containing the server certificate "
+    "to check against.",
+)
+@click.option(
+    "--certificate-file",
+    "-c",
+    type=click.Path(),
+    help="Certificate to connect to vault. "
+    'Configuration file can also contain a "certificate" key.',
+)
+@click.option(
+    "--token-file",
+    "-T",
+    type=click.Path(),
+    help="File which contains the token to connect to Vault. "
+    'Configuration file can also contain a "token" key.',
+)
+@click.option("--username", "-u", help="Username used for userpass authentication")
+@click.option(
+    "--password-file",
+    "-w",
+    type=click.Path(),
+    help='Can read from stdin if "-" is used as parameter. '
+    'Configuration file can also contain a "password" key.',
+)
+@click.option("--base-path", "-b", help="Base path for requests")
+@click.option(
+    "--backend",
+    default=settings.DEFAULTS["backend"],
+    help="Name of the backend to use (requests, hvac)",
+)
+@click.option(
+    "--config-file",
+    is_eager=True,
+    callback=load_config,
+    help="Config file to use. Use 'no' to disable config file. "
+    "Default value: first of " + ", ".join(settings.CONFIG_FILES),
+    type=click.Path(),
+)
 def cli(ctx, **kwargs):
     """
     Interact with a Vault. See subcommands for details.
@@ -106,7 +129,7 @@ def extract_special_args(config, environ):
 
 
 @cli.command("list")
-@click.argument('path', required=False, default='')
+@click.argument("path", required=False, default="")
 @click.pass_obj
 def list_(client_obj, path):
     """
@@ -117,8 +140,8 @@ def list_(client_obj, path):
     click.echo("\n".join(result))
 
 
-@cli.command(name='get-all')
-@click.argument('path', required=False, nargs=-1)
+@cli.command(name="get-all")
+@click.argument("path", required=False, nargs=-1)
 @click.pass_obj
 def get_all(client_obj, path):
     """
@@ -130,19 +153,22 @@ def get_all(client_obj, path):
 
     result = client_obj.get_all(paths)
 
-    click.echo(yaml.safe_dump(
-        result,
-        default_flow_style=False,
-        explicit_start=True), nl=False)
+    click.echo(
+        yaml.safe_dump(result, default_flow_style=False, explicit_start=True), nl=False
+    )
 
 
 @cli.command()
 @click.pass_obj
-@click.option('--text',
-              is_flag=True,
-              help=("--text implies --without-key. Returns the value in "
-                    "plain text format instead of yaml."))
-@click.argument('name')
+@click.option(
+    "--text",
+    is_flag=True,
+    help=(
+        "--text implies --without-key. Returns the value in "
+        "plain text format instead of yaml."
+    ),
+)
+@click.argument("name")
 def get(client_obj, text, name):
     """
     Return a single secret value.
@@ -152,17 +178,17 @@ def get(client_obj, text, name):
         click.echo(secret)
         return
 
-    click.echo(yaml.safe_dump(secret,
-                              default_flow_style=False,
-                              explicit_start=True), nl=False)
+    click.echo(
+        yaml.safe_dump(secret, default_flow_style=False, explicit_start=True), nl=False
+    )
 
 
 @cli.command("set")
 @click.pass_obj
-@click.option('--yaml', 'format_yaml', is_flag=True)
-@click.option('--stdin/--no-stdin', default=False)
-@click.argument('name')
-@click.argument('value', nargs=-1)
+@click.option("--yaml", "format_yaml", is_flag=True)
+@click.option("--stdin/--no-stdin", default=False)
+@click.argument("name")
+@click.argument("value", nargs=-1)
 def set_(client_obj, format_yaml, stdin, name, value):
     """
     Set a single secret to the given value(s).
@@ -174,7 +200,7 @@ def set_(client_obj, format_yaml, stdin, name, value):
         raise click.UsageError("Can't set both --stdin and a value")
 
     if stdin:
-        value = click.get_text_stream('stdin').read().strip()
+        value = click.get_text_stream("stdin").read().strip()
 
     elif len(value) == 1:
         value = value[0]
@@ -186,18 +212,18 @@ def set_(client_obj, format_yaml, stdin, name, value):
         value = yaml.safe_load(value)
 
     client_obj.set_secret(path=name, value=value)
-    click.echo('Done')
+    click.echo("Done")
 
 
 @cli.command()
 @click.pass_obj
-@click.argument('name')
+@click.argument("name")
 def delete(client_obj, name):
     """
     Deletes a single secret.
     """
     client_obj.delete_secret(path=name)
-    click.echo('Done')
+    click.echo("Done")
 
 
 def main():

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -80,9 +80,11 @@ def get_client_from_kwargs(backend, **kwargs):
     """
     if backend == "requests":
         from vault_cli import requests
+
         client_class = requests.RequestsVaultClient
     elif backend == "hvac":
         from vault_cli import hvac
+
         client_class = hvac.HVACVaultClient
     elif callable(backend):
         client_class = backend
@@ -93,12 +95,11 @@ def get_client_from_kwargs(backend, **kwargs):
 
 
 class VaultAPIException(Exception):
-
     def __init__(self, status_code, body, *args, **kwargs):
         super(VaultAPIException, self).__init__(*args, **kwargs)
         self.status_code = status_code
         try:
-            self.error = '\n'.join(json.loads(body)['errors'])
+            self.error = "\n".join(json.loads(body)["errors"])
         except Exception:
             self.error = body
 
@@ -106,9 +107,10 @@ class VaultAPIException(Exception):
         return 'status={} error="{}"'.format(self.status_code, self.error)
 
 
-class VaultClientBase():
-    def __init__(self, url, verify, ca_bundle, base_path,
-                 certificate, token, username, password):
+class VaultClientBase:
+    def __init__(
+        self, url, verify, ca_bundle, base_path, certificate, token, username, password
+    ):
         """
         All parameters are mandatory but may be None
         """
@@ -126,7 +128,7 @@ class VaultClientBase():
             self._authenticate_certificate(certificate)
         elif username:
             if not password:
-                raise ValueError('Cannot use username without password file')
+                raise ValueError("Cannot use username without password file")
             self._authenticate_userpass(username=username, password=password)
 
         else:
@@ -134,12 +136,12 @@ class VaultClientBase():
 
     def _get_recursive_secrets(self, path):
         result = {}
-        path = path.rstrip('/')
+        path = path.rstrip("/")
         for key in self.list_secrets(path=path):
-            key_url = '/'.join([path, key]) if path else key
+            key_url = "/".join([path, key]) if path else key
 
-            folder = key_url.endswith('/')
-            key = key.rstrip('/')
+            folder = key_url.endswith("/")
+            key = key.rstrip("/")
             if folder:
                 result[key] = self._get_recursive_secrets(key_url)
                 continue
@@ -195,7 +197,7 @@ def nested_keys(path, value):
     {'test': {'bla': 'foo'}}
     """
     try:
-        base, subpath = path.strip('/').split('/', 1)
+        base, subpath = path.strip("/").split("/", 1)
     except ValueError:
         return {path: value}
     return {base: nested_keys(subpath, value)}

--- a/vault_cli/hvac.py
+++ b/vault_cli/hvac.py
@@ -20,7 +20,6 @@ limitations under the License.
 from typing import Iterable
 
 import hvac
-
 from vault_cli import types
 from vault_cli.client import VaultAPIException, VaultClientBase
 

--- a/vault_cli/hvac.py
+++ b/vault_cli/hvac.py
@@ -20,13 +20,10 @@ limitations under the License.
 from __future__ import absolute_import
 
 import hvac
-
-from vault_cli.client import VaultAPIException
-from vault_cli.client import VaultClientBase
+from vault_cli.client import VaultAPIException, VaultClientBase
 
 
 class HVACVaultClient(VaultClientBase):
-
     def _init_session(self, url, verify):
         self.client = hvac.Client(url=url, verify=verify)
 

--- a/vault_cli/hvac.py
+++ b/vault_cli/hvac.py
@@ -20,6 +20,7 @@ limitations under the License.
 from typing import Iterable
 
 import hvac
+
 from vault_cli import types
 from vault_cli.client import VaultAPIException, VaultClientBase
 

--- a/vault_cli/hvac.py
+++ b/vault_cli/hvac.py
@@ -17,36 +17,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import
+from typing import Iterable
 
 import hvac
+
+from vault_cli import types
 from vault_cli.client import VaultAPIException, VaultClientBase
 
 
 class HVACVaultClient(VaultClientBase):
-    def _init_session(self, url, verify):
+    def _init_session(self, url: str, verify: types.VerifyOrCABundle) -> None:
         self.client = hvac.Client(url=url, verify=verify)
 
-    def _authenticate_token(self, token):
+    def _authenticate_token(self, token: str) -> None:
         self.client.token = token
 
-    def _authenticate_userpass(self, username, password):
+    def _authenticate_userpass(self, username: str, password: str) -> None:
         self.client.auth_userpass(username, password)
 
-    def list_secrets(self, path):
+    def list_secrets(self, path: str) -> Iterable[str]:
         secrets = self.client.list(self.base_path + path)
         if not secrets:
             return []
         return secrets["data"]["keys"]
 
-    def get_secret(self, path):
+    def get_secret(self, path: str) -> types.JSONValue:
         secret = self.client.read(self.base_path + path)
         if not secret:
             raise VaultAPIException(404, "Not found")
         return secret["data"]["value"]
 
-    def delete_secret(self, path):
+    def delete_secret(self, path: str) -> None:
         self.client.delete(self.base_path + path)
 
-    def set_secret(self, path, value):
+    def set_secret(self, path: str, value: types.JSONValue) -> None:
         self.client.write(self.base_path + path, value=value)

--- a/vault_cli/requests.py
+++ b/vault_cli/requests.py
@@ -18,17 +18,13 @@ limitations under the License.
 """
 
 from __future__ import absolute_import
+from urllib.parse import urljoin
 
 import requests
 import urllib3
 
 from vault_cli.client import VaultAPIException, VaultClientBase
 
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    # Python 2
-    from urlparse import urljoin
 
 
 class Session(requests.Session):

--- a/vault_cli/settings.py
+++ b/vault_cli/settings.py
@@ -19,13 +19,10 @@ limitations under the License.
 
 import os
 import sys
+from functools import lru_cache
 
 import yaml
 
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache
 
 ENV_PREFIX = "VAULT_CLI"
 

--- a/vault_cli/settings.py
+++ b/vault_cli/settings.py
@@ -30,22 +30,18 @@ except ImportError:
 ENV_PREFIX = "VAULT_CLI"
 
 # Ordered by increasing priority
-CONFIG_FILES = [
-    './.vault.yml',
-    '~/.vault.yml',
-    '/etc/vault.yml',
-]
+CONFIG_FILES = ["./.vault.yml", "~/.vault.yml", "/etc/vault.yml"]
 
 DEFAULTS = {
-    'backend': 'requests',
-    'base_path': None,
-    'certificate': None,
-    'password': None,
-    'token': None,
-    'url': 'http://localhost:8200',
-    'username': None,
-    'verify': True,
-    'ca_bundle': None,
+    "backend": "requests",
+    "base_path": None,
+    "certificate": None,
+    "password": None,
+    "token": None,
+    "url": "http://localhost:8200",
+    "username": None,
+    "verify": True,
+    "ca_bundle": None,
 }
 
 
@@ -60,16 +56,15 @@ def read_config_file(file_path):
 def dash_to_underscores(config):
     # Because we're modifying the dict during iteration, we need to
     # consolidate the keys into a list
-    return {key.replace("-", "_"): value
-            for key, value in config.items()}
+    return {key.replace("-", "_"): value for key, value in config.items()}
 
 
 def load_bool(value):
     lower_value = value.lower()
 
-    if lower_value in ('true', 't', '1', 'yes', 'y'):
+    if lower_value in ("true", "t", "1", "yes", "y"):
         return True
-    elif lower_value in ('false', 'f', '0', 'no', 'n'):
+    elif lower_value in ("false", "f", "0", "no", "n"):
         return False
 
     raise ValueError("Value {} could not be interpreted as boolean")
@@ -126,7 +121,7 @@ def read_file(path):
     if path == "-":
         return sys.stdin.read().strip()
 
-    with open(os.path.expanduser(path), 'rb') as file_handler:
+    with open(os.path.expanduser(path), "rb") as file_handler:
         return file_handler.read().decode("utf-8").strip()
 
 

--- a/vault_cli/types.py
+++ b/vault_cli/types.py
@@ -1,0 +1,9 @@
+import typing as t
+
+JSONValue = t.Union[str, int, float, bool, None, t.Dict[str, t.Any], t.List[t.Any]]
+JSONDict = t.Dict[str, JSONValue]
+
+Settings = t.Union[str, bool, None]
+SettingsDict = t.Dict[str, Settings]
+
+VerifyOrCABundle = t.Union[bool, str]


### PR DESCRIPTION
This PR:
- Introduces proper linting with flake8 (configured to play nice with Black)
- Adds black as an autoformatter
- Removes Python 2.7 in order to...
- ... Add(s) type hints and mypy everywhere
- Add isort (configured to play nice with black)
- Add support for Python 3.7
- Rework the tox integration
- And finally test all this in Travis