### PR TITLE
Fix a typo: s/autent/authent/

### DIFF
--- a/vault_cli/exceptions.py
+++ b/vault_cli/exceptions.py
@@ -56,7 +56,7 @@ class VaultUnauthorized(VaultAPIException):
 
 
 class VaultForbidden(VaultAPIException):
-    message = "Invalid autentication"
+    message = "Invalid authentication"
 
 
 class VaultSecretNotFound(VaultAPIException):


### PR DESCRIPTION
Fix a typo: `s/autent/authent/`