### PR TITLE
Allow to write secret when if 'read' and/or 'list' accesses are not allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.5.1 (2019-06-06)
+------------------
+
+- Don't prevent write access when read or list access isn't allowed
+
 0.5.0 (2019-05-28)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Be warned.
 
 ## License
 
-Copyright 2018 PeopleDoc
+Copyright 2018-2019 PeopleDoc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = vault-cli
 description = CLI tool for hashicorp vault
-version = 0.5.1
+version = 0.5.2.dev0
 author = ylachiver
 author_email = yann.lachiver@people-doc.com
 url = https://github.com/peopledoc/vault-cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = vault-cli
 description = CLI tool for hashicorp vault
-version = 0.5.1.dev0
+version = 0.5.1
 author = ylachiver
 author_email = yann.lachiver@people-doc.com
 url = https://github.com/peopledoc/vault-cli

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -244,7 +244,7 @@ class VaultClientBase:
             if problematic_secrets:
                 secrets = [f"{path}/{secret}" for secret in problematic_secrets]
                 raise exceptions.VaultMixSecretAndFolder(
-                    f"Cannot create a secret at {path} because it is already a "
+                    f"Cannot create a secret at '{path}' because it is already a "
                     f"folder containing {', '.join(secrets)}"
                 )
         except exceptions.VaultForbidden:
@@ -264,7 +264,7 @@ class VaultClientBase:
                 )
             else:
                 raise exceptions.VaultMixSecretAndFolder(
-                    f"Cannot create a secret at {path} because '{parent}' already exists as a secret"
+                    f"Cannot create a secret at '{path}' because '{parent}' already exists as a secret"
                 )
 
         self._set_secret(path=path, value=value)

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -231,16 +231,25 @@ class VaultClientBase:
             self.get_secret(path=path)
         except exceptions.VaultSecretNotFound:
             pass
+        except exceptions.VaultForbidden:
+            logger.warning(
+                f"Read access '{path}' forbidden: if it exists, secret will be overridden."
+            )
         else:
             if not force:
                 raise exceptions.VaultOverwriteSecretError(path=path)
 
-        problematic_secrets = self.list_secrets(path=path)
-        if problematic_secrets:
-            secrets = [f"{path}/{secret}" for secret in problematic_secrets]
-            raise exceptions.VaultMixSecretAndFolder(
-                f"Cannot create a secret at {path} because it is already a "
-                f"folder containing {', '.join(secrets)}"
+        try:
+            problematic_secrets = self.list_secrets(path=path)
+            if problematic_secrets:
+                secrets = [f"{path}/{secret}" for secret in problematic_secrets]
+                raise exceptions.VaultMixSecretAndFolder(
+                    f"Cannot create a secret at {path} because it is already a "
+                    f"folder containing {', '.join(secrets)}"
+                )
+        except exceptions.VaultForbidden:
+            logger.info(
+                f"List '{path}' forbidden: if it exists, secret will be overridden."
             )
 
         path = path.rstrip("/")
@@ -249,9 +258,13 @@ class VaultClientBase:
                 self.get_secret(str(parent))
             except exceptions.VaultSecretNotFound:
                 pass
+            except exceptions.VaultForbidden:
+                logger.info(
+                    f"Read access '{parent}' forbidden: cannot check if a secret exists here."
+                )
             else:
                 raise exceptions.VaultMixSecretAndFolder(
-                    f"Cannot create a secret at {path} because {str(parent)} already exists as a secret"
+                    f"Cannot create a secret at {path} because '{parent}' already exists as a secret"
                 )
 
         self._set_secret(path=path, value=value)


### PR DESCRIPTION
Allow to write secret when if `read` and/or `list` accesses are not allowed.

Using the below policy, `VaultForbidden` exception is raised because user don't have `list` access:
```
path "secret/testproject/secret" {
  capabilities = ["read", "create", "update"]
}
```
Same exception occurs when:
- user is allowed to create and/or update a secret but not to read the related path
- user isn't allowed to read parent paths