### PR TITLE
Safe write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.6.0 (unreleased)
+------------------
+
+- Add --safe-write. 0.5.1's behaviour of not allowing overwriting without -f is not the default anymore.
+
 0.5.1 (2019-06-06)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -24,26 +24,30 @@ Usage: vault [OPTIONS] COMMAND [ARGS]...
   VAULT_CLI_TOKEN).
 
 Options:
-  -U, --url TEXT            URL of the vault instance
-  --verify / --no-verify    Verify HTTPS certificate
-  --ca-bundle PATH          Location of the bundle containing the server
-                            certificate to check against.
-  --login-cert PATH           Path to a public client certificate to use for
-                            connecting to vault.
-  --login-cert-key PATH          Path to a private client certificate to use for
-                            connecting to vault.
-  -T, --token-file PATH     File which contains the token to connect to Vault.
-                            Configuration file can also contain a "token" key.
-  -u, --username TEXT       Username used for userpass authentication
-  -w, --password-file PATH  Can read from stdin if "-" is used as parameter.
-                            Configuration file can also contain a "password"
-                            key.
-  -b, --base-path TEXT      Base path for requests
-  -v, --verbose             Use multiple times to increase verbosity
-  --config-file PATH        Config file to use. Use 'no' to disable config
-                            file. Default value: first of ./.vault.yml,
-                            ~/.vault.yml, /etc/vault.yml
-  -h, --help                Show this message and exit.
+  -U, --url TEXT                  URL of the vault instance
+  --verify / --no-verify          Verify HTTPS certificate
+  --ca-bundle PATH                Location of the bundle containing the server
+                                  certificate to check against.
+  -c, --certificate-file PATH     Certificate to connect to vault.
+                                  Configuration file can also contain a
+                                  "certificate" key.
+  -T, --token-file PATH           File which contains the token to connect to
+                                  Vault. Configuration file can also contain a
+                                  "token" key.
+  -u, --username TEXT             Username used for userpass authentication
+  -w, --password-file PATH        Can read from stdin if "-" is used as
+                                  parameter. Configuration file can also
+                                  contain a "password" key.
+  -b, --base-path TEXT            Base path for requests
+  -s, --safe-write / --unsafe-write
+                                  When activated, you can't overwrite a secret
+                                  without passing "--force" (in commands "set"
+                                  and "mv")
+  -v, --verbose                   Use multiple times to increase verbosity
+  --config-file PATH              Config file to use. Use 'no' to disable
+                                  config file. Default value: first of
+                                  ./.vault.yml, ~/.vault.yml, /etc/vault.yml
+  -h, --help                      Show this message and exit.
 
 Commands:
   delete       Delete a single secret.
@@ -143,6 +147,18 @@ $ vault get list_secret
 - secret2
 - secret3
 ```
+
+### Protect yourself from overwriting a secret by mistake
+
+```console
+vault set a b
+Done
+$ vault --safe-write set a c
+Error: Secret already exists at a. Use -f to force overwriting.
+$ vault --safe-write set -f a c
+Done
+```
+(`safe-write` can be set in your configuration file, see below for details)
 
 ### Get all values from the vault in a single command (yaml format)
 ```console

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -289,7 +289,7 @@ def test_dump_config(cli_runner, vault):
         input="some-token",
     )
 
-    expected_settings = settings.DEFAULTS.copy()
+    expected_settings = settings.DEFAULTS._as_dict()
     expected_settings.update(
         {"base_path": "mybase/", "token": "some-token", "verbose": 0}
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,8 @@ import yaml
 
 from vault_cli import cli, exceptions, settings
 
+# To debug cli_runner.invoke, add the argument "catch_exceptions=False"
+
 
 def test_options(cli_runner, mocker):
     client = mocker.patch("vault_cli.client.get_client_class").return_value

--- a/tests/unit/test_client_base.py
+++ b/tests/unit/test_client_base.py
@@ -52,7 +52,7 @@ def test_vault_client_base_call_init_client():
         username=None,
         password=None,
         ca_bundle=None,
-    )
+    ).auth()
 
     assert called_with == {
         "verify": False,
@@ -94,7 +94,9 @@ def test_vault_client_base_authenticate(test_kwargs, expected):
         "login_cert_key": None,
     }
     kwargs.update(test_kwargs)
-    TestVaultClient(verify=False, url=None, base_path=None, ca_bundle=None, **kwargs)
+    TestVaultClient(
+        verify=False, url=None, base_path=None, ca_bundle=None, **kwargs
+    ).auth()
 
     assert auth_params == expected
 
@@ -134,7 +136,7 @@ def test_vault_client_base_login_cert_without_key():
             login_cert="a",
             login_cert_key=None,
             ca_bundle=None,
-        )
+        ).auth()
 
 
 def test_vault_client_base_no_auth():
@@ -153,7 +155,7 @@ def test_vault_client_base_no_auth():
             login_cert=None,
             login_cert_key=None,
             ca_bundle=None,
-        )
+        ).auth()
 
 
 @pytest.mark.parametrize(
@@ -179,7 +181,7 @@ def test_vault_client_ca_bundle_verify(mocker, verify, ca_bundle, expected):
             base_path=None,
             login_cert=None,
             login_cert_key=None,
-        )
+        ).auth()
 
     assert session_kwargs["verify"] == expected
 

--- a/tests/unit/test_client_base.py
+++ b/tests/unit/test_client_base.py
@@ -39,20 +39,10 @@ def test_vault_client_base_call_init_client():
         def _init_client(self, **kwargs):
             called_with.update(kwargs)
 
-        def _authenticate_token(self, *args, **kwargs):
+        def _authenticate_certificate(self, *args, **kwargs):
             pass
 
-    TestVaultClient(
-        verify=False,
-        url="yay",
-        token="go",
-        base_path=None,
-        login_cert="a",
-        login_cert_key="b",
-        username=None,
-        password=None,
-        ca_bundle=None,
-    ).auth()
+    TestVaultClient(verify=False, url="yay", login_cert="a", login_cert_key="b").auth()
 
     assert called_with == {
         "verify": False,
@@ -86,76 +76,30 @@ def test_vault_client_base_authenticate(test_kwargs, expected):
         def _authenticate_userpass(self, username, password):
             auth_params.extend(["userpass", username, password])
 
-    kwargs = {
-        "token": None,
-        "username": None,
-        "password": None,
-        "login_cert": None,
-        "login_cert_key": None,
-    }
-    kwargs.update(test_kwargs)
-    TestVaultClient(
-        verify=False, url=None, base_path=None, ca_bundle=None, **kwargs
-    ).auth()
+    TestVaultClient(**test_kwargs).auth()
 
     assert auth_params == expected
 
 
-def test_vault_client_base_username_without_password():
-    class TestVaultClient(client.VaultClientBase):
-        def _init_client(self, **kwargs):
-            pass
+def test_vault_client_base_username_without_password(vault):
+
+    vault.username = "yay"
 
     with pytest.raises(exceptions.VaultAuthenticationError):
-        TestVaultClient(
-            username="yay",
-            password=None,
-            verify=False,
-            url="yay",
-            token=None,
-            base_path=None,
-            login_cert=None,
-            login_cert_key=None,
-            ca_bundle=None,
-        )
+        vault.auth()
 
 
-def test_vault_client_base_login_cert_without_key():
-    class TestVaultClient(client.VaultClientBase):
-        def _init_client(self, **kwargs):
-            pass
+def test_vault_client_base_login_cert_without_key(vault):
+    vault.login_cert = "yay"
 
     with pytest.raises(exceptions.VaultAuthenticationError):
-        TestVaultClient(
-            username=None,
-            password=None,
-            verify=False,
-            url="yay",
-            token=None,
-            base_path=None,
-            login_cert="a",
-            login_cert_key=None,
-            ca_bundle=None,
-        ).auth()
+        vault.auth()
 
 
-def test_vault_client_base_no_auth():
-    class TestVaultClient(client.VaultClientBase):
-        def _init_client(self, **kwargs):
-            pass
+def test_vault_client_base_no_auth(vault):
 
     with pytest.raises(exceptions.VaultAuthenticationError):
-        TestVaultClient(
-            username=None,
-            password=None,
-            verify=False,
-            url="yay",
-            token=None,
-            base_path=None,
-            login_cert=None,
-            login_cert_key=None,
-            ca_bundle=None,
-        ).auth()
+        vault.auth()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_client_base.py
+++ b/tests/unit/test_client_base.py
@@ -271,23 +271,32 @@ def test_vault_client_set_secret(vault):
     assert vault.db == {"a/b": "c"}
 
 
-def test_vault_client_set_secret_overwrite(vault):
+@pytest.mark.parametrize(
+    "safe_write, force", [(True, False), (True, None), (False, False)]
+)
+def test_vault_client_set_secret_overwrite_invalid(vault, safe_write, force):
 
     vault.db = {"a/b": "d"}
+    vault.safe_write = safe_write
 
     with pytest.raises(exceptions.VaultOverwriteSecretError):
-        vault.set_secret("a/b", "c")
+        vault.set_secret("a/b", "c", force=force)
 
     assert vault.db == {"a/b": "d"}
 
 
-def test_vault_client_set_secret_overwrite_force(vault):
+@pytest.mark.parametrize(
+    "safe_write, force, value",
+    [(True, True, "c"), (False, None, "c"), (True, None, "d")],
+)
+def test_vault_client_set_secret_overwrite_valid(vault, safe_write, force, value):
 
     vault.db = {"a/b": "d"}
+    vault.safe_write = safe_write
 
-    vault.set_secret("a/b", "c", force=True)
+    vault.set_secret("a/b", value, force=force)
 
-    assert vault.db == {"a/b": "c"}
+    assert vault.db == {"a/b": value}
 
 
 def test_vault_client_set_secret_when_there_are_existing_secrets_beneath_path(vault):

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -75,7 +75,7 @@ def test_build_config_from_files_no_files(mocker):
 
     result = settings.build_config_from_files("a")
 
-    assert result == settings.DEFAULTS
+    assert result == settings.DEFAULTS._as_dict()
 
 
 def test_get_vault_options(mocker):

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -7,3 +7,9 @@ import pytest
 def test_fake_client_list_secrets(vault, path, expected):
     vault.db = {"a": "A", "b/c": "BC", "b/d": "BD"}
     assert vault.list_secrets(path) == expected
+
+
+def test_auth_does_nothing(vault):
+    vault._init_client()
+    vault._authenticate_token()
+    vault._authenticate_userpass()

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -48,11 +48,11 @@ def handle_errors():
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 @click.option(
-    "--url", "-U", help="URL of the vault instance", default=settings.DEFAULTS["url"]
+    "--url", "-U", help="URL of the vault instance", default=settings.DEFAULTS.url
 )
 @click.option(
     "--verify/--no-verify",
-    default=settings.DEFAULTS["verify"],
+    default=settings.DEFAULTS.verify,
     help="Verify HTTPS certificate",
 )
 @click.option(

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -1,7 +1,7 @@
 import contextlib
 import logging
 import os
-from typing import Any, Dict, Mapping, NoReturn, Sequence, TextIO
+from typing import Any, Dict, Mapping, NoReturn, Optional, Sequence, TextIO
 
 import click
 import yaml
@@ -87,6 +87,13 @@ def handle_errors():
     'Configuration file can also contain a "password" key.',
 )
 @click.option("--base-path", "-b", help="Base path for requests")
+@click.option(
+    "-s",
+    "--safe-write/--unsafe-write",
+    default=settings.DEFAULTS.safe_write,
+    help="When activated, you can't overwrite a secret without "
+    'passing "--force" (in commands "set" and "mv")',
+)
 @click.option(
     "-v",
     "--verbose",
@@ -203,11 +210,12 @@ def get(client_obj: client.VaultClientBase, text: bool, name: str):
 @click.option("--yaml", "format_yaml", is_flag=True)
 @click.option("--stdin/--no-stdin", default=False)
 @click.option(
-    "--force",
+    "--force/--no-force",
     "-f",
     is_flag=True,
-    default=False,
-    help="In case the path already holds a secret, allow overwriting it.",
+    default=None,
+    help="In case the path already holds a secret, allow overwriting it "
+    "(this is necessary only if --safe-write is set).",
 )
 @click.argument("name")
 @click.argument("value", nargs=-1)
@@ -218,7 +226,7 @@ def set_(
     stdin: bool,
     name: str,
     value: Sequence[str],
-    force: bool,
+    force: Optional[bool],
 ):
     """
     Set a single secret to the given value(s).
@@ -351,11 +359,12 @@ def delete_all(
 @click.argument("source", required=True)
 @click.argument("dest", required=True)
 @click.option(
-    "--force",
+    "--force/--no-force",
     "-f",
     is_flag=True,
     default=False,
-    help="In case the path already holds a secret, allow overwriting it.",
+    help="In case the path already holds a secret, allow overwriting it "
+    "(this is necessary only if --safe-write is set).",
 )
 @click.pass_obj
 @handle_errors()

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -123,6 +123,7 @@ def cli(ctx: click.Context, **kwargs) -> None:
     saved_settings.update({"verbose": verbose})
 
     ctx.obj = client.get_client_class()(**kwargs)  # type: ignore
+    ctx.obj.auth()
     ctx.obj.saved_settings = saved_settings
 
 

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -63,7 +63,9 @@ def get_client(**kwargs) -> "VaultClientBase":
         all the secrets under those paths. Use with extreme caution.
     """
     options = settings.get_vault_options(**kwargs)
-    return get_client_class()(**options)
+    client = get_client_class()(**options)
+    client.auth()
+    return client
 
 
 def get_client_class() -> Type["VaultClientBase"]:
@@ -76,51 +78,58 @@ class VaultClientBase:
 
     def __init__(
         self,
-        url: str,
-        verify: bool,
-        ca_bundle: str,
-        base_path: str,
-        login_cert: Optional[str],
-        login_cert_key: Optional[str],
-        token: str,
-        username: str,
-        password: str,
+        url: str = settings.DEFAULTS.url,
+        verify: bool = settings.DEFAULTS.verify,
+        ca_bundle: Optional[str] = settings.DEFAULTS.ca_bundle,
+        base_path: Optional[str] = settings.DEFAULTS.base_path,
+        login_cert: Optional[str] = settings.DEFAULTS.login_cert,
+        login_cert_key: Optional[str] = settings.DEFAULTS.login_cert_key,
+        token: Optional[str] = settings.DEFAULTS.token,
+        username: Optional[str] = settings.DEFAULTS.username,
+        password: Optional[str] = settings.DEFAULTS.password,
+        safe_write: bool = settings.DEFAULTS.safe_write,
     ):
         """
         All parameters are mandatory but may be None
         """
+        self.url = url
+        self.verify: types.VerifyOrCABundle = verify
+        self.ca_bundle = ca_bundle
+        self.base_path = base_path or ""
+        self.login_cert = login_cert
+        self.login_cert_key = login_cert_key
+        self.token = token
+        self.username = username
+        self.password = password
+        self.safe_write = safe_write
 
-        verify_ca_bundle: types.VerifyOrCABundle = verify
-        if verify and ca_bundle:
-            verify_ca_bundle = ca_bundle
+    def auth(self):
+        verify_ca_bundle = self.verify
+        if self.verify and self.ca_bundle:
+            verify_ca_bundle = self.ca_bundle
 
         # Temporary workaround for https://github.com/urllib3/urllib3/issues/497
         requests.packages.urllib3.disable_warnings()
 
-        self._init_client(
-            url=url,
-            verify=verify_ca_bundle,
-            login_cert=login_cert,
-            login_cert_key=login_cert_key,
-        )
+        self._init_client(url=self.url, verify=verify_ca_bundle)
 
-        self.base_path = (base_path or "").rstrip("/") + "/"
+        self.base_path = (self.base_path or "").rstrip("/") + "/"
 
-        if token:
-            self._authenticate_token(token)
-        elif login_cert:
-            if login_cert_key:
+        if self.token:
+            self._authenticate_token(self.token)
+        elif self.login_cert:
+            if self.login_cert_key:
                 self._authenticate_certificate()
             else:
                 raise exceptions.VaultAuthenticationError(
                     "Cannot use certificate file for login without key file"
                 )
-        elif username:
-            if not password:
+        elif self.username:
+            if not self.password:
                 raise exceptions.VaultAuthenticationError(
                     "Cannot use username without password file"
                 )
-            self._authenticate_userpass(username=username, password=password)
+            self._authenticate_userpass(username=self.username, password=self.password)
 
         else:
             raise exceptions.VaultAuthenticationError(

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -258,7 +258,7 @@ class VaultClientBase:
                 f"Read access '{path}' forbidden: if it exists, secret will be overridden."
             )
         else:
-            if not force:
+            if not force and existing_value != value:
                 raise exceptions.VaultOverwriteSecretError(path=path)
 
         try:

--- a/vault_cli/testing.py
+++ b/vault_cli/testing.py
@@ -10,6 +10,21 @@ class TestVaultClient(client.VaultClientBase):
         self.forbidden_list_paths = set()
         self.forbidden_get_paths = set()
 
+        super().__init__(**kwargs)
+
+    def update_settings(self, **kwargs):
+        vars(self).update(kwargs)
+        return self
+
+    def _init_client(self, *args, **kwargs):
+        pass
+
+    def _authenticate_token(self, *args, **kwargs):
+        pass
+
+    def _authenticate_userpass(self, *args, **kwargs):
+        pass
+
     def get_secret(self, path):
         if path in self.forbidden_get_paths:
             raise exceptions.VaultForbidden()
@@ -45,6 +60,6 @@ class TestVaultClient(client.VaultClientBase):
 def vault(mocker):
     backend = TestVaultClient()
     mocker.patch(
-        "vault_cli.client.get_client_class", return_value=lambda **kwargs: backend
+        "vault_cli.client.get_client_class", return_value=backend.update_settings
     )
     yield backend

--- a/vault_cli/testing.py
+++ b/vault_cli/testing.py
@@ -9,12 +9,9 @@ class TestVaultClient(client.VaultClientBase):
         self.db = {}
         self.forbidden_list_paths = set()
         self.forbidden_get_paths = set()
+        self.freeze_settings = False
 
         super().__init__(**kwargs)
-
-    def update_settings(self, **kwargs):
-        vars(self).update(kwargs)
-        return self
 
     def _init_client(self, *args, **kwargs):
         pass
@@ -59,7 +56,5 @@ class TestVaultClient(client.VaultClientBase):
 @pytest.fixture
 def vault(mocker):
     backend = TestVaultClient()
-    mocker.patch(
-        "vault_cli.client.get_client_class", return_value=backend.update_settings
-    )
+    mocker.patch("vault_cli.client.get_client_class", return_value=lambda **k: backend)
     yield backend


### PR DESCRIPTION
Based on #71 

This PR introduces `--safe-write`, which makes the previous introduction of `--force` a non-breaking change.

In the end, ``safe-write`` and ``--force`` are analogous, with opposite defaults, but it makes it easier to decide if you want to work with safe-write on or off in your config file, and then just use `--force` (which you can't set in your config file) when you need, or if you don't care.

Of course, we could still do that with a single argument but it would be quite less clear.