### PR TITLE
Customize environment variables names in vault env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
 - Add `vault lookup-token` (#77)
 - Remove `client.get_all()` (after deprecation period)
 - Add template values and `--render` features in client and cli (#65)
+- Add possibility to customize environment variables names in `vault env` using
+  `--path path/to/keys=myprefix`
 
 0.6.0 (2019-15-06)
 ------------------

--- a/README.md
+++ b/README.md
@@ -238,9 +238,16 @@ third_secret: '----BEGIN SECRET KEY----
 ```console
 $ vault env --path blob_secret -- env
 ...
-code=supercode
+BLOB_SECRET={"code": "supercode"}
+...
+$ vault set foo/bar/service/instance/dsn value
+$ vault env --path blob_secret=blob --path foo/bar/service/instance=my -- env
+...
+BLOB={"code": "supercode"}
+MY_DSN=value
 ...
 ```
+
 
 ### Render a template file with values from the vault
 ```console

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -243,6 +243,22 @@ def test_env(cli_runner, vault_with_token, mocker):
     assert kwargs["environ"]["FOO_BAZ"] == "yo"
 
 
+def test_env_prefix(cli_runner, vault_with_token, mocker):
+    exec_command = mocker.patch("vault_cli.environment.exec_command")
+
+    vault_with_token.db = {"foo/bar": "yay", "foo/baz": "yo"}
+    cli_runner.invoke(
+        cli.cli,
+        ["env", "--path", "foo=prefix", "--", "echo", "yay"],
+        catch_exceptions=False,
+    )
+
+    _, kwargs = exec_command.call_args
+    assert kwargs["command"] == ("echo", "yay")
+    assert kwargs["environ"]["PREFIX_BAR"] == "yay"
+    assert kwargs["environ"]["PREFIX_BAZ"] == "yo"
+
+
 def test_main(mocker):
     mock_cli = mocker.patch("vault_cli.cli.cli")
     environ = mocker.patch("os.environ", {})

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -12,11 +12,22 @@ def test_exec_command(mocker):
 
 
 @pytest.mark.parametrize(
-    "path, key, expected",
-    [("", "a", "A"), ("", "a/b", "A_B"), ("a", "a/b", "A_B"), ("a/b", "a/b/c", "B_C")],
+    "path, prefix, key, expected",
+    [
+        ("", None, "a", "A"),
+        ("a", None, "a", "A"),
+        ("", None, "a/b", "A_B"),
+        ("a", None, "a/b", "A_B"),
+        ("a/b", None, "a/b/c", "B_C"),
+        ("", "foo", "a", "FOO_A"),
+        ("a", "foo", "a", "FOO"),
+        ("", "foo", "a/b", "FOO_A_B"),
+        ("a", "foo", "a/b", "FOO_B"),
+        ("a/b", "foo", "a/b/c", "FOO_C"),
+    ],
 )
-def test_make_env_key(path, key, expected):
-    assert environment.make_env_key(path=path, key=key) == expected
+def test_make_env_key(path, prefix, key, expected):
+    assert environment.make_env_key(path=path, prefix=prefix, key=key) == expected
 
 
 @pytest.mark.parametrize(

--- a/vault_cli/environment.py
+++ b/vault_cli/environment.py
@@ -1,13 +1,18 @@
 import json
 import os
 import pathlib
-from typing import Dict, NoReturn, Sequence
+from typing import Dict, NoReturn, Optional, Sequence
 
 from vault_cli import types
 
 
-def make_env_key(path: str, key: str) -> str:
-    relative = pathlib.Path(key).relative_to(pathlib.Path(path).parent)
+def make_env_key(path: str, prefix: Optional[str], key: str) -> str:
+    if prefix:
+        relative = pathlib.Path(prefix) / pathlib.Path(key).relative_to(
+            pathlib.Path(path)
+        )
+    else:
+        relative = pathlib.Path(key).relative_to(pathlib.Path(path).parent)
     return str(relative).upper().replace("/", "_")
 
 


### PR DESCRIPTION
Add possibility to customize environment variables names in `vault env`
using `--path path/to/keys=myprefix`

- If the path is not a folder the prefix value is used as the name of the
variable.
e.g.: for a/b/key, `--path a/b/c=foo` gives `FOO=...`
- If the path is a folder, then the variable names will be generated as:
`PREFIX + _ + relative path`
e.g.: for a/b/key, `--path a/b=my` gives `MY_KEY=...`

- The standard behavior has not changed and will generate variable names
as:
`relative path to the parent of the given path`
e.g.: for a/b/key, `--path a/b` gives `B_KEY=...`

Cf. #ticket-number

### Check list:
- [x] Write unit tests (100% coverage ?)
- [x] Write or edit integration tests, if applicable ?
- [x] Add a line in CHANGELOG.md
