### PR TITLE
Isolate tests from env vars

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+
+from vault_cli import settings
+
+
+@pytest.fixture(autouse=True)
+def isolate_tests():
+
+    for key in os.environ:
+        if key.startswith(settings.ENV_PREFIX):
+            os.environ.pop(key)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -97,15 +97,9 @@ def test_integration_lib(clean_vault):
     assert client.lookup_token()["data"]
 
 
-@pytest.fixture
-def environ():
-    yield os.environ
-    os.environ.pop("VAULT_CLI_TOKEN")
-
-
-def test_env_var_config(environ):
+def test_env_var_config():
     # Test env var config
-    environ["VAULT_CLI_TOKEN"] = "some-other-token"
+    os.environ["VAULT_CLI_TOKEN"] = "some-other-token"
     with pytest.raises(vault_cli.VaultAPIException):
         vault_cli.get_client().set_secret("a", "b")
 


### PR DESCRIPTION
Closes #88 

I can't see a way to properly isolate fs without multiplying the test suite time by more than 100.

### Check list:
- [ ] Write unit tests (100% coverage ?)
- [ ] Write or edit integration tests, if applicable ?
- [ ] Add a line in CHANGELOG.md
