### PR TITLE
Sort the output of vault list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ master (unreleased)
 
 - Add a `--prompt` option to prompt user to fill the secret value without showing it in the history or the screen (#94).
 - Can now read secrets that are not stored in a "value" key (#97)
+- Sort the output of `vault list`
 
 0.8.0 (2019-07-05)
 ------------------

--- a/tests/unit/test_client_hvac.py
+++ b/tests/unit/test_client_hvac.py
@@ -93,6 +93,12 @@ def test_list_secrets(mock_hvac):
     mock_hvac.list.assert_called_with("bla/a")
 
 
+def test_list_secrets_sorted(mock_hvac):
+    mock_hvac.list.return_value = {"data": {"keys": ["b", "A", "c"]}}
+
+    assert get_client()._list_secrets("bla/a") == ["A", "b", "c"]
+
+
 def test_list_secrets_empty(mock_hvac):
     mock_hvac.list.return_value = None
 

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -456,7 +456,7 @@ class VaultClient(VaultClientBase):
         secrets = self.client.list(path)
         if not secrets:
             return []
-        return secrets["data"]["keys"]
+        return sorted(secrets["data"]["keys"])
 
     @handle_errors()
     def _get_secret(self, path: str) -> Dict[str, types.JSONValue]:


### PR DESCRIPTION
It's much more easier to read when it's sorted :)

I can't reproduce the issue in my dev env, but using a postgres storage in production I had unsorted output.

Cf. #ticket-number

### Check list:
- [x] Write unit tests (100% coverage ?)
- [x] Write or edit integration tests, if applicable ?
- [x] Add a line in CHANGELOG.md
