### PR TITLE
 Add implicit and explicit caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ dist
 htmlcov
 .tox
 *.pyc
-/.vault-token
-/.vault.yml
+/vault.yml
 /.mypy_cache

--- a/tests/unit/test_client_base.py
+++ b/tests/unit/test_client_base.py
@@ -414,16 +414,16 @@ def test_vault_client_base_get_secrets_error(vault):
 @pytest.mark.parametrize(
     "method, params, expected",
     [
-        ("get_secret", ["foo"], {"path": "base/foo"}),
+        ("get_secret", ["foo"], {"path": "/base/foo"}),
         ("get_secret", ["/foo"], {"path": "/foo"}),
-        ("delete_secret", ["foo"], {"path": "base/foo"}),
+        ("delete_secret", ["foo"], {"path": "/base/foo"}),
         ("delete_secret", ["/foo"], {"path": "/foo"}),
-        ("list_secrets", ["foo"], {"path": "base/foo"}),
+        ("list_secrets", ["foo"], {"path": "/base/foo"}),
         ("list_secrets", ["/foo"], {"path": "/foo"}),
         (
             "set_secret",
             ["foo", "value"],
-            {"path": "base/foo", "secret": {"value": "value"}},
+            {"path": "/base/foo", "secret": {"value": "value"}},
         ),
         (
             "set_secret",
@@ -440,14 +440,22 @@ def test_vault_client_base_absolute_path(vault, mocker, method, params, expected
     mocked.assert_called_with(**expected)
 
 
-@pytest.mark.parametrize("path, expected", [("foo", "base/foo"), ("/foo", "/foo")])
+@pytest.mark.parametrize("path, expected", [("foo", "/base/foo"), ("/foo", "/foo")])
 def test_vault_client_base_build_full_path(vault, path, expected):
     vault.base_path = "base/"
     assert vault._build_full_path(path) == expected
 
 
 @pytest.mark.parametrize(
-    "path, expected", [("foo", "foo/"), ("foo/", "foo/"), ("foo//", "foo/")]
+    "path, expected",
+    [
+        ("foo", "/foo/"),
+        ("foo/", "/foo/"),
+        ("foo//", "/foo/"),
+        ("/foo", "/foo/"),
+        ("/foo/", "/foo/"),
+        ("/foo//", "/foo/"),
+    ],
 )
 def test_vault_client_base_base_path(vault, path, expected):
     vault.base_path = path

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -130,7 +130,7 @@ class VaultClientBase:
     @base_path.setter
     def base_path(self, path: str):
         # ensure the base_path ends with a single '/'
-        self._base_path = (path.rstrip("/") + "/") if path else ""
+        self._base_path = (f"/{path.strip('/')}/") if path else ""
 
     def auth(self):
         verify_ca_bundle = self.verify


### PR DESCRIPTION
Fixes #102

- Add implicit caching (or "poor man's atomicity", if you prefer: in a single vault-cli call, each secret is never read more than once)
- Add explicit caching, via `with client.caching()`. Sadly, the vault cli lib is not documented, this is something to tackle someday
- Add recursive templates: as long as it's not an infinite recursion, templates will be rendered recursively.
- Fixes a small issue: now all calls will had a path with a leading `/`. This helps caching because it helps canonicalizing paths.

### Check list:
- [x] Write unit tests (100% coverage ?)
- [ ] Write or edit integration tests, if applicable ?
- [x] Add a line in CHANGELOG.md
