### PR TITLE
Enable --flat by default on `vault get-all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -------------------
 
 - Remove the hard-coded "value" key used in get/set (#104)
+- Enable --flat by default on `vault get-all`
 
 0.13.0 (2020-02-04)
 -------------------

--- a/README.md
+++ b/README.md
@@ -437,6 +437,26 @@ The following list shows how to update your commands:
 (new) vault env --path path/to/creds:value=FOO -- env  # FOO=xxx
 ```
 
+The default output of `vault get-all` has also changed and is now flat by default (this
+behavior is controlled with the `--flat/--no-flat` flags).
+
+```sh
+$ vault set a/b secret=xxx
+$ vault set a/c secret=xxx
+$ vault get-all a
+---
+a/b:
+  secret: xxx
+a/c:
+  secret: xxx
+$ vault get-all --no-flat a
+---
+a:
+  b:
+    secret: xxx
+  c:
+    secret: xxx
+```
 
 ## Troubleshooting
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -59,20 +59,20 @@ def test_integration_cli(cli_runner, clean_vault):
         """---
 a:
   value: b
+c/d:
+  bar: f
+  foo: e
+"""
+    )
+
+    assert call(cli_runner, ["get-all", "--no-flat"]).output == (
+        """---
+a:
+  value: b
 c:
   d:
     bar: f
     foo: e
-"""
-    )
-
-    assert call(cli_runner, ["get-all", "--flat", ""]).output == (
-        """---
-a:
-  value: b
-c/d:
-  bar: f
-  foo: e
 """
     )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -124,10 +124,10 @@ def test_get_yaml(cli_runner, vault_with_token):
     assert result.exit_code == 0
 
 
-def test_get_all(cli_runner, vault_with_token):
+def test_get_all_no_flat(cli_runner, vault_with_token):
 
     vault_with_token.db = {"a/baz": {"value": "bar"}, "a/foo": {"value": "yay"}}
-    result = cli_runner.invoke(cli.cli, ["get-all", "a"])
+    result = cli_runner.invoke(cli.cli, ["get-all", "--no-flat", "a"])
 
     assert yaml.safe_load(result.output) == {
         "a": {"baz": {"value": "bar"}, "foo": {"value": "yay"}}
@@ -138,7 +138,7 @@ def test_get_all(cli_runner, vault_with_token):
 def test_get_all_flat(cli_runner, vault_with_token):
 
     vault_with_token.db = {"a/baz": {"value": "bar"}, "a/foo": {"value": "yay"}}
-    result = cli_runner.invoke(cli.cli, ["get-all", "--flat", "a"])
+    result = cli_runner.invoke(cli.cli, ["get-all", "a"])
 
     assert yaml.safe_load(result.output) == {
         "a/baz": {"value": "bar"},

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -197,8 +197,9 @@ def list_(client_obj: client.VaultClientBase, path: str):
 
 @cli.command(name="get-all")
 @click.option(
-    "--flat",
-    is_flag=True,
+    "--flat/--no-flat",
+    default=True,
+    show_default=True,
     help=("Returns the full path as keys instead of merging paths into a tree"),
 )
 @click.argument("path", required=False, nargs=-1)


### PR DESCRIPTION
Release 1.x introduces major changes in the API, we take this
opportunity to change the default output of `vault get-all` to the
"flat" version, that better differentiates between paths and mapping
values.

Cf. #ticket-number

### Check list:
- [x] Write unit tests (100% coverage ?)
- [x] Write or edit integration tests, if applicable ?
- [x] Add a line in CHANGELOG.md
