### PR TITLE
Fixes #135 trailing slash in path issue in `get-all` and `delete-all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 - Omit secrets in `vault env` when path contains forbidden chars (#138)
 - `vault env` fails properly when program name is not supplied
 - `vault env` now supports `-` and ` ` (spaces) in variable names, changing them into `_`
+- Fix trailing slash in path issue in `get-all` and `delete-all` (#135)
 
 1.1.0 (2020-02-28)
 -------------------

--- a/tests/unit/test_client_base.py
+++ b/tests/unit/test_client_base.py
@@ -137,6 +137,10 @@ def test_vault_client_base_get_all_secrets(vault):
 
     assert result == {"a": {"c": {"value": "secret-ac"}}}
 
+    result = vault.get_all_secrets("a/")
+
+    assert result == {"a": {"c": {"value": "secret-ac"}}}
+
 
 def test_vault_client_base_get_all_secrets_flat(vault):
     vault.db = {"a/c": {"value": "secret-ac"}, "b": {"value": "secret-b"}}
@@ -152,13 +156,16 @@ def test_vault_client_base_get_all_secrets_flat(vault):
 
 @pytest.mark.parametrize(
     "input, expected",
-    [("a", {"a/c": {"value": "secret-ac"}}), ("b", {"b": {"value": "secret-b"}})],
+    [
+        ("a", {"a/c": {"value": "secret-ac"}}),
+        ("b", {"b": {"value": "secret-b"}}),
+        ("a/", {"a/c": {"value": "secret-ac"}}),
+    ],
 )
 def test_vault_client_base_get_secrets(vault, input, expected):
     vault.db = {"a/c": {"value": "secret-ac"}, "b": {"value": "secret-b"}}
 
     result = vault.get_secrets(input)
-
     assert result == expected
 
 
@@ -199,6 +206,14 @@ def test_vault_client_base_delete_all_secrets_no_generator(vault):
     result = vault.delete_all_secrets("a", "b")
 
     assert result == ["a/c", "b"]
+
+    assert vault.db == {}
+
+
+def test_vault_client_base_delete_all_secrets_trailing_slash(vault):
+    vault.db = {"a/c": {"value": "secret-ac"}}
+
+    assert vault.delete_all_secrets("a/") == ["a/c"]
 
     assert vault.db == {}
 

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -265,6 +265,7 @@ class VaultClientBase:
         types.JSONDict
             {"folder/subfolder": {"secret_key": "secret_value"}}
         """
+        path = path.rstrip("/")
         try:
             secrets_paths = list(
                 self._browse_recursive_secrets(path=path, render=render)
@@ -400,6 +401,7 @@ class VaultClientBase:
 
     def delete_all_secrets_iter(self, *paths: str) -> Iterable[str]:
         for path in paths:
+            path = path.rstrip("/")
             secrets_paths = self._browse_recursive_secrets(path=path, render=False)
             for secret_path in secrets_paths:
                 yield secret_path

--- a/vault_cli/testing.py
+++ b/vault_cli/testing.py
@@ -23,6 +23,7 @@ class TestVaultClient(client.VaultClientBase):
         pass
 
     def _get_secret(self, path):
+        path = path.rstrip("/")
         if path in self.forbidden_get_paths:
             raise exceptions.VaultForbidden()
         try:
@@ -31,6 +32,7 @@ class TestVaultClient(client.VaultClientBase):
             raise exceptions.VaultSecretNotFound()
 
     def _list_secrets(self, path):
+        path = path.rstrip("/")
         if path in self.forbidden_list_paths:
             raise exceptions.VaultForbidden()
         # Just reproducing in memory the behaviour of the real list_secrets


### PR DESCRIPTION
Co-Authored-By: Joachim Jablon<ewjoachim@gmail.com>

Cf. #135 

### Check list:
- [ ] Write unit tests (100% coverage ?)
- [ ] Write or edit integration tests, if applicable ?
- [ ] Add a line in CHANGELOG.md
