### PR TITLE
PyYAML<5.3.1 has a CVE, we should really avoid it

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find:
 install_requires =
     requests
     Click>=7.0
-    pyyaml
+    pyyaml>=5.3.1
     jinja2
     hvac
 


### PR DESCRIPTION
@mgu Honnestly I'm not sure if it's our responsibility or if we should use restriction only for the version that we break with. What's your call ?

### Check list:
- [ ] Write documentation (we can help you doing so)
- [ ] Write unit tests (100% coverage ?)
- [ ] Write or edit integration tests, if applicable ?
- [ ] Add a line in CHANGELOG.md
