### PR TITLE
Refactor vault-cli env, rename --path to --envvar (with compat)

### DIFF
--- a/docs/howto/environment.rst
+++ b/docs/howto/environment.rst
@@ -26,7 +26,7 @@ A path option looks like this:
 
 .. code:: console
 
-    $ vault-cli env --path [path/]{root}[:key][=prefix] [--path ...] -- {command...}
+    $ vault-cli env --envvar [path/]{root}[:key][=prefix] [--envvar ...] -- {command...}
 
 - The optional ``path/`` allows you to indicate the location of the secret(s) you want
   to expose. If the root begins with a `/`, the ``base-path`` option will be ignored
@@ -45,10 +45,9 @@ A path option looks like this:
 - You can limit a secret object to expose a single key by specifying ``:key``. In this
   case, the environment variable name will just be the key.
 - If a ``=prefix`` is provided, it replaces the ``root`` or ``:key`` part.
-- Lastly, paths such as ``--path ""`` or ``--path =prefix`` are valid to express
-  "all the secrets under``base-path``", although doing this can create a risk of
-  exposing more secrets than intended. A sub-path is recommended in that case.
-
+- Lastly, paths such as ``--envvar ""``, ``--envvar .`` or ``--envvar =prefix`` are
+  valid to express "all the secrets under``base-path``", although doing this can create
+  a risk of exposing more secrets than intended. A sub-path is recommended in that case.
 
 All parts of the secret environment variable name are uppercased, special characters
 ``/``, ``-`` and  `` `` (space) are changed to ``_``. If an environment variable still

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -354,6 +354,15 @@ def test_env_error(cli_runner, vault_with_token, mocker):
     exec_command.assert_not_called()
 
 
+def test_env_envvar_format_error(cli_runner):
+    result = cli_runner.invoke(
+        cli.cli, ["env", "--envvar", ":foo", "--", "echo", "yay"]
+    )
+
+    assert result.exit_code != 0
+    assert "Cannot omit the path if a filter key is provided" in result.output
+
+
 def test_env_error_force_sub_error(cli_runner, vault_with_token, mocker):
     exec_command = mocker.patch("vault_cli.environment.exec_command")
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -851,3 +851,20 @@ def test_ensure_str():
 def test_ensure_str_wrong():
     with pytest.raises(exceptions.VaultWrongType):
         cli.ensure_str(1, "bar")
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    [
+        ("aa:bb=cc", ("aa", "bb", "cc")),
+        ("aa:bb", ("aa", "bb", "")),
+        ("aa=cc", ("aa", "", "cc")),
+        ("aa", ("aa", "", "")),
+        (":bb=cc", ("", "bb", "cc")),
+        ("=cc", ("", "", "cc")),
+        (":bb", ("", "bb", "")),
+        ("", ("", "", "")),
+    ],
+)
+def test_get_env_parts(input, output):
+    assert cli.get_env_parts(input) == output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -336,7 +336,7 @@ def test_env(cli_runner, vault_with_token, mocker):
     exec_command = mocker.patch("vault_cli.environment.exec_command")
 
     vault_with_token.db = {"foo/bar": {"value": "yay"}, "foo/baz": {"value": "yo"}}
-    cli_runner.invoke(cli.cli, ["env", "--path", "foo", "--", "echo", "yay"])
+    cli_runner.invoke(cli.cli, ["env", "--envvar", "foo", "--", "echo", "yay"])
 
     _, kwargs = exec_command.call_args
     assert kwargs["command"] == ("echo", "yay")
@@ -349,7 +349,7 @@ def test_env_error(cli_runner, vault_with_token, mocker):
 
     vault_with_token.forbidden_get_paths.add("foo")
 
-    cli_runner.invoke(cli.cli, ["env", "--path", "foo", "--", "echo", "yay"])
+    cli_runner.invoke(cli.cli, ["env", "--envvar", "foo", "--", "echo", "yay"])
 
     exec_command.assert_not_called()
 
@@ -359,7 +359,9 @@ def test_env_error_force_sub_error(cli_runner, vault_with_token, mocker):
 
     vault_with_token.forbidden_get_paths.add("foo")
 
-    cli_runner.invoke(cli.cli, ["env", "--path", "foo", "--force", "--", "echo", "yay"])
+    cli_runner.invoke(
+        cli.cli, ["env", "--envvar", "foo", "--force", "--", "echo", "yay"]
+    )
 
     exec_command.assert_called()
 
@@ -369,7 +371,9 @@ def test_env_error_force_main_error(cli_runner, vault_with_token, mocker):
 
     vault_with_token.forbidden_list_paths.add("foo")
 
-    cli_runner.invoke(cli.cli, ["env", "--path", "foo", "--force", "--", "echo", "yay"])
+    cli_runner.invoke(
+        cli.cli, ["env", "--envvar", "foo", "--force", "--", "echo", "yay"]
+    )
 
     exec_command.assert_called()
 
@@ -381,7 +385,7 @@ def test_env_prefix(cli_runner, vault_with_token, mocker):
         "foo/bar": {"value": "yay"},
         "foo/baz": {"user": "yo", "password": "xxx"},
     }
-    cli_runner.invoke(cli.cli, ["env", "--path", "foo=prefix", "--", "echo", "yay"])
+    cli_runner.invoke(cli.cli, ["env", "--envvar", "foo=prefix", "--", "echo", "yay"])
 
     _, kwargs = exec_command.call_args
     assert kwargs["command"] == ("echo", "yay")
@@ -422,7 +426,7 @@ def test_env_omit_single_key(cli_runner, vault_with_token, mocker):
 
     vault_with_token.db = {"foo/bar": {"value": "yay"}, "foo/baz": {"password": "yo"}}
     cli_runner.invoke(
-        cli.cli, ["env", "--path", "foo", "--omit-single-key", "--", "echo", "yay"]
+        cli.cli, ["env", "--envvar", "foo", "--omit-single-key", "--", "echo", "yay"]
     )
 
     _, kwargs = exec_command.call_args

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -508,9 +508,8 @@ def env(
 
     env_secrets = {}
 
-    for path in paths:
-        path_with_key, _, prefix = path.partition("=")
-        path, _, filter_key = path_with_key.partition(":")
+    for path in envvars:
+        path, key, prefix = get_env_parts(path)
 
         env_updates = {}
         env_updates = environment.get_envvars(
@@ -518,7 +517,7 @@ def env(
             path=path,
             prefix=prefix,
             omit_single_key=omit_single_key,
-            filter_key=filter_key,
+            filter_key=key,
         )
 
         env_secrets.update(env_updates)
@@ -526,6 +525,12 @@ def env(
     if bool(client_obj.errors) and not force:
         raise click.ClickException("There was an error while reading the secrets.")
     environment.exec_command(command=command, environment=env_secrets)
+
+
+def get_env_parts(value: str) -> Tuple[str, str, str]:
+    part12, _, part3 = value.partition("=")
+    part1, _, part2 = part12.partition(":")
+    return part1, part2, part3
 
 
 @cli.command("dump-config")

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -663,9 +663,9 @@ def template(client_obj: client.VaultClientBase, template: str, output: TextIO) 
         template_text = sys.stdin.read()
         search_path = pathlib.Path.cwd()
     else:
-        with open(template, mode="r") as ftemplate:
-            template_text = ftemplate.read()
-        search_path = pathlib.Path(template).parent
+        template_path = pathlib.Path(template)
+        template_text = template_path.read_text()
+        search_path = template_path.parent
 
     result = client_obj.render_template(template_text, search_path=search_path)
     output.write(result)

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -518,6 +518,10 @@ def env(
 
     for path in envvars:
         path, key, prefix = get_env_parts(path)
+        if not path and key:
+            raise click.BadOptionUsage(
+                "envvar", "Cannot omit the path if a filter key is provided"
+            )
 
         env_updates = {}
         env_updates = environment.get_envvars(

--- a/vault_cli/cli.py
+++ b/vault_cli/cli.py
@@ -453,10 +453,17 @@ def delete(client_obj: client.VaultClientBase, name: str, key: Optional[str]) ->
 @cli.command("env")
 @click.option(
     "-p",
+    "--envvar",
     "--path",
     multiple=True,
-    required=True,
-    help="Folder or single item. Pass several times to load multiple values. You can use --path mypath=prefix or --path mypath:key=prefix if you want to change the generated names of the environment variables",
+    help="""
+    Load a secret from this path into one or more environment variables. Secret can be a
+    folder or single item. Pass several times to load secrets from different paths. You
+    can use --envvar mypath=prefix or --envvar mypath:key=prefix if you want to change
+    the generated names of the environment variables. --path is the original option
+    name, --envvar was added later for clarity, both work identically, and neither is
+    formerly deprecated. See command help for details.
+    """,
 )
 @click.option(
     "-o",
@@ -475,20 +482,21 @@ def delete(client_obj: client.VaultClientBase, name: str, key: Optional[str]) ->
 @handle_errors()
 def env(
     client_obj: client.VaultClientBase,
-    path: Sequence[str],
+    envvar: Sequence[str],
     omit_single_key: bool,
     force: bool,
     command: Sequence[str],
 ) -> NoReturn:
     """
-    Launch a command, loading secrets in environment.
+    Write secrets to disk, load secrets in environment variable, then  lauch a command.
 
-    Strings are exported as-is, other types (including booleans, nulls, dicts, lists)
-    are exported JSON-encoded.
+    Secrets stored as strings are loaded as-is. Secrets of any other type exported as an
+    environment variable are JSON-encoded. Secrets of any other type written to a file
+    are YAML-encoded.
+
+    LOADING ENVIRONMENT VARIABLES
 
     If the path ends with `:key` then only one key of the mapping is used and its name is the name of the key.
-
-    VARIABLE NAMES
 
     By default the name is build upon the relative path to the parent of the given path (in parameter) and the name of the keys in the value mapping.
     Let's say that we have stored the mapping `{'username': 'me', 'password': 'xxx'}` at path `a/b/c`
@@ -504,7 +512,7 @@ def env(
     Using `--path a/b/c=FOO` will inject the following environment variables: FOO_USERNAME and FOO_PASSWORD
     Using `--path a/b/c:username=FOO` will inject `FOO=me` in the environment.
     """
-    paths = list(path) or [""]
+    envvars = list(envvar) or []
 
     env_secrets = {}
 


### PR DESCRIPTION
- Use pathlib to write template
- Refactor the split by : and =
- vault env: --path is now --envvar but --path/-p is still accepted
- Add a clean error on invalid envvar format 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests (units, integration, 100% coverage)
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
- [x] Had a good time contributing?
