### PR TITLE
Use a logger warning otherwise it's not displayed properly.

### DIFF
--- a/tests/unit/test_client_base.py
+++ b/tests/unit/test_client_base.py
@@ -522,11 +522,12 @@ def test_vault_client_base_get_secret(vault, vault_contents, expected):
     assert vault.get_secret("a") == expected
 
 
-def test_vault_client_base_get_secret_deprecation_warning(vault):
+def test_vault_client_base_get_secret_deprecation_warning(vault, caplog):
     vault.db = {"a": {"value": "!template!b"}}
+    caplog.set_level("WARNING")
 
-    with pytest.warns(DeprecationWarning):
-        assert vault.get_secret("a") == {"value": "b"}
+    vault.get_secret("a")
+    assert "Templated values are deprecated" in caplog.records[0].message
 
 
 def test_vault_client_base_get_secret_template_root(vault):

--- a/vault_cli/client.py
+++ b/vault_cli/client.py
@@ -2,7 +2,6 @@ import contextlib
 import json
 import logging
 import pathlib
-import warnings
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Type, Union, cast
 
 import hvac  # type: ignore
@@ -522,13 +521,6 @@ class VaultClientBase:
 
     def _render_template_value(self, secret: types.JSONValue) -> types.JSONValue:
 
-        warnings.warn(
-            DeprecationWarning(
-                "Templated values are deprecated and will be removed in the "
-                "following major versions."
-            )
-        )
-
         if isinstance(secret, dict):
             return {k: self._render_template_value(v) for k, v in secret.items()}
         if not isinstance(secret, str):
@@ -537,6 +529,10 @@ class VaultClientBase:
         if not secret.startswith(self.template_prefix):
             return secret
 
+        logger.warn(
+            "Templated values are deprecated and will be removed in the "
+            "following major versions.",
+        )
         return self.render_template(secret[len(self.template_prefix) :])
 
     def _render_template_dict(


### PR DESCRIPTION
Also move the warning to the correct location

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests (units, integration, 100% coverage)
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [ ] Had a good time contributing?
